### PR TITLE
Change sno-bmh-tests - root device hints.

### DIFF
--- a/scenarios/sno-bmh-tests/manifests/dataplane/baremetal_hosts.yaml.j2
+++ b/scenarios/sno-bmh-tests/manifests/dataplane/baremetal_hosts.yaml.j2
@@ -20,7 +20,7 @@ spec:
   bootMode: UEFI
   online: false
   rootDeviceHints:
-    deviceName: /dev/sda
+    deviceName: /dev/vda
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -44,7 +44,7 @@ spec:
   bootMode: UEFI
   online: false
   rootDeviceHints:
-    deviceName: /dev/sda
+    deviceName: /dev/vda
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
@@ -67,4 +67,4 @@ spec:
   bootMode: UEFI
   online: false
   rootDeviceHints:
-    deviceName: /dev/sda
+    deviceName: /dev/vda


### PR DESCRIPTION
No suitable device was found for deployment using these hints {'name': 's== /dev/sda'}. Change to /dev/vda ...