### PR TITLE
Update sushy-emulator image

### DIFF
--- a/roles/redfish_virtual_bmc/files/deployment.yaml
+++ b/roles/redfish_virtual_bmc/files/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             path: clouds.yaml
       containers:
       - name: sushy-emulator
-        image: quay.io/rhn_gps_hjensas/sushy-tools:dev-1740174755
+        image: quay.io/rhn_gps_hjensas/sushy-tools:dev-1743118089
         command: ["/usr/local/bin/sushy-emulator", "--config", "/etc/sushy-emulator/config.conf"]
         ports:
         - containerPort: 8000

--- a/roles/redfish_virtual_bmc/templates/config_map.yaml.j2
+++ b/roles/redfish_virtual_bmc/templates/config_map.yaml.j2
@@ -30,6 +30,10 @@ data:
     # import OpenStack cloud virtual media
     SUSHY_EMULATOR_OS_VMEDIA_IMAGE_FILE_UPLOAD = True
 
+    # When set to true, the instance rebuild on virtual media eject
+    # is delayed until the next a RedFish power action.
+    SUSHY_EMULATOR_OS_VMEDIA_DELAY_EJECT = True
+
     # Instruct the libvirt driver to ignore any instructions to
     # set the boot device. Allowing the UEFI firmware to instead
     # rely on the EFI Boot Manager


### PR DESCRIPTION
Use sushy-emulator image with support for delay rebuild on eject. 
See: https://review.opendev.org/c/openstack/sushy-tools/+/945800

Also, set `SUSHY_EMULATOR_OS_VMEDIA_DELAY_EJECT = True` in config.