### PR TITLE
Add a sleep for Metal platform Provisioning CR

### DIFF
--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -54,6 +54,7 @@ stages:
       Create a Provisioning custom resource (CR) to enable OCP Metal platform components
     manifest: ../common/provisioning.yaml
     wait_conditions:
+      - "sleep 30"
       - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=300s"
 
   - name: Common OLM


### PR DESCRIPTION
Add a sleep for 30 seconds before running wait conditions, the wait command fails "error: no matching resources found".