### PR TITLE
Bump the disk size for bmh's in sno-bmh-tests

### DIFF
--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -584,7 +584,7 @@ resources:
         - device_type: disk
           boot_index: 1
           image_id: {get_param: [bmh_params, image]}
-          volume_size: 40
+          volume_size: 60
           delete_on_termination: true
         - device_type: cdrom
           disk_bus: scsi
@@ -649,7 +649,7 @@ resources:
         - device_type: disk
           boot_index: 1
           image_id: {get_param: [bmh_params, image]}
-          volume_size: 40
+          volume_size: 60
           delete_on_termination: true
         - device_type: cdrom
           disk_bus: scsi
@@ -718,7 +718,7 @@ resources:
         - device_type: disk
           boot_index: 1
           image_id: {get_param: [bmh_params, image]}
-          volume_size: 40
+          volume_size: 60
           delete_on_termination: true
         - device_type: cdrom
           disk_bus: scsi


### PR DESCRIPTION
Error: writing blob: adding layer with blob "...": unpacking failed (error: exit status 1;
output: open /usr/lib/python3.9/site-packages/openstackclient/tests/functional/ compute/v2/__pycache__/test_flavor.cpython-39.opt-1.pyc:
  no space left on device)
fatal: [edpm-compute-2]: FAILED! =>
  {"changed": false, "msg": "Failed containers: ovn_metadata_agent"}