### PR TITLE
Disable barbican service in controlplane

### DIFF
--- a/scenarios/sno-bmh-tests/manifests/control-plane/control-plane.yaml
+++ b/scenarios/sno-bmh-tests/manifests/control-plane/control-plane.yaml
@@ -7,28 +7,7 @@ metadata:
   namespace: openstack
 spec:
   barbican:
-    apiOverride:
-      route: {}
-    template:
-      barbicanAPI:
-        override:
-          service:
-            internal:
-              metadata:
-                annotations:
-                  metallb.universe.tf/address-pool: internalapi
-                  metallb.universe.tf/allow-shared-ip: internalapi
-                  metallb.universe.tf/loadBalancerIPs: 172.17.0.80
-              spec:
-                type: LoadBalancer
-        replicas: 1
-      barbicanKeystoneListener:
-        replicas: 1
-      barbicanWorker:
-        replicas: 1
-      databaseInstance: openstack
-      preserveJobs: false
-      secret: osp-secret
+    enabled: false
   ceilometer:
     enabled: false
   cinder:


### PR DESCRIPTION
... keep it simple. The goal is to test bmh provisioning + dataplane.