### PR TITLE
Make external and fip network configurable

### DIFF
--- a/01-infra.yml
+++ b/01-infra.yml
@@ -30,3 +30,5 @@
           ntp_servers: "{{ ntp_servers }}"
           controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
           dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+          router_external_network: "{{ os_router_external_network | default('public') }}"
+          floating_ip_network: "{{ os_floating_network | default('public') }}"

--- a/scenarios/3-nodes/bootstrap_vars.yml
+++ b/scenarios/3-nodes/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: 3-nodes

--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -37,6 +37,9 @@ parameters:
   router_external_network:
     type: string
     default: public
+  floating_ip_network:
+    type: string
+    default: public
 
 resources:
   #
@@ -266,7 +269,7 @@ resources:
      depends_on: machine-net-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:

--- a/scenarios/campus-ha/bootstrap_vars.yml
+++ b/scenarios/campus-ha/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: campus-ha

--- a/scenarios/campus-ha/heat_template.yaml
+++ b/scenarios/campus-ha/heat_template.yaml
@@ -366,7 +366,7 @@ resources:
      depends_on: machine-net-a-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:

--- a/scenarios/hci/bootstrap_vars.yml
+++ b/scenarios/hci/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: hci

--- a/scenarios/hci/heat_template.yaml
+++ b/scenarios/hci/heat_template.yaml
@@ -37,7 +37,9 @@ parameters:
   router_external_network:
     type: string
     default: public
-
+  floating_ip_network:
+    type: string
+    default: public
 
 resources:
   #
@@ -328,7 +330,7 @@ resources:
      depends_on: machine-net-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:

--- a/scenarios/sno-2-bm/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: sno-2-bm

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -38,6 +38,9 @@ parameters:
   router_external_network:
     type: string
     default: public
+  floating_ip_network:
+    type: string
+    default: public
 
 resources:
   #
@@ -271,7 +274,7 @@ resources:
      depends_on: machine-net-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:

--- a/scenarios/sno-bmh-tests/bootstrap_vars.yml
+++ b/scenarios/sno-bmh-tests/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: sno-bmh-tests

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -38,6 +38,9 @@ parameters:
   router_external_network:
     type: string
     default: public
+  floating_ip_network:
+    type: string
+    default: public
 
 resources:
   #
@@ -396,7 +399,7 @@ resources:
      depends_on: machine-net-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:

--- a/scenarios/uni01alpha/bootstrap_vars.yml
+++ b/scenarios/uni01alpha/bootstrap_vars.yml
@@ -1,5 +1,8 @@
 os_cloud: default
 os_keypair: default
+os_floating_network: public
+os_router_external_network: public
+
 controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 scenario: uni01alpha

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -49,7 +49,9 @@ parameters:
   router_external_network:
     type: string
     default: public
-
+  floating_ip_network:
+    type: string
+    default: public
 
 resources:
   #
@@ -345,7 +347,7 @@ resources:
      depends_on: machine-net-router-interface
      type: OS::Neutron::FloatingIP
      properties:
-       floating_network: public
+       floating_network: {get_param: floating_ip_network}
        port_id: {get_resource: controller-machine-port}
 
   controller:


### PR DESCRIPTION
The floatingip_network was hard-coded to "public" in all the example scenario heat templates. This change adds a new variable to make that user configurable.

The bootstrap_vars.yaml files have the following new vars as example.

  os_floating_network: public
  os_router_external_network: public

Change those, or override on the commandline with -e <var_name> with values appropriate for the cloud being used.