### PR TITLE
Move stack_parameters to bootstrap_vars

### DIFF
--- a/01-infra.yml
+++ b/01-infra.yml
@@ -23,12 +23,5 @@
       vars:
         os_cloud: "{{ os_cloud }}"
         stack_name: "{{ stack_name }}"
-        stack_template_path: "{{ template_path }}"
-        stack_parameters:
-          keypair: "{{ os_keypair }}"
-          dns_servers: "{{ dns_servers }}"
-          ntp_servers: "{{ ntp_servers }}"
-          controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
-          dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
-          router_external_network: "{{ os_router_external_network | default('public') }}"
-          floating_ip_network: "{{ os_floating_network | default('public') }}"
+        stack_template_path: "{{ stack_template_path }}"
+        stack_parameters: "{{ stack_parameters }}"

--- a/README.md
+++ b/README.md
@@ -70,12 +70,23 @@ download packages, since it is using itself as the resolver ...
 
 See documentation [here](./images/README.md)
 
-### An xxlarge flavor (much memory)
+### Create flavors 
 
-Create the `m1.xxlarge` flavor with 32 GB of ram.
+Create flavors to use for the instances. This creates flavors with the
+hotstack_ prefix that matches the defaults in scenario's heat templates and
+bootstrap variable files. 
+
+> **_NOTE:_** Creating flavors is typically not allowed for regular users.
+> 
+> It is possible to use existing flavors by overriding the stack_parameters
+> variable in the bootstrap variable files in scenarios.
 
 ```bash
-openstack flavor create m1.xxlarge --public --vcpus 12 --ram 32768 --disk 160
+openstack flavor create hotstack.small   --public --vcpus  1 --ram  2048 --disk  20
+openstack flavor create hotstack.medium  --public --vcpus  2 --ram  4096 --disk  40
+openstack flavor create hotstack.large   --public --vcpus  4 --ram  8192 --disk  80
+openstack flavor create hotstack.xlarge  --public --vcpus  8 --ram 16384 --disk 160
+openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 160
 ```
 
 ### Cloud secret
@@ -98,6 +109,13 @@ cloud_secrets:
   interface: public
   identity_api_version: 3
   auth_type: v3applicationcredential
+```
+
+### Ansible collections (Dependencies)
+
+```
+ansible-galaxy collection install community.crypto
+ansible-galaxy collection install openstack.cloud
 ```
 
 ## Bootstrap playbook
@@ -130,8 +148,7 @@ can be used:
 ```bash
 ansible-playbook -i inventory.yml bootstrap.yml \
   -e @scenarios/uni01alpha/bootstrap_vars.yml \
-  -e @/home/cloud-user/cloud-secrets.yaml \
-  -e scenario_dir=./scenarios
+  -e @~/cloud-secrets.yaml \
 ```
 
 Edit or override the variables in the `bootstrap_vars.yml` to select the

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -30,10 +30,14 @@ vgextend cinder-volumes /dev/sdc
 
 ## Cloud configuration
 
-### Flavor
+### Flavors
 
 ```shell
-openstack flavor create m1.xxlarge --public --vcpus 8 --ram 32768 --disk 160
+openstack flavor create hotstack.small   --public --vcpus  1 --ram  2048 --disk  20
+openstack flavor create hotstack.medium  --public --vcpus  2 --ram  4096 --disk  40
+openstack flavor create hotstack.large   --public --vcpus  4 --ram  8192 --disk  80
+openstack flavor create hotstack.xlarge  --public --vcpus  8 --ram 16384 --disk 160
+openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 160
 ```
 
 ### Project

--- a/roles/heat_stack/README.md
+++ b/roles/heat_stack/README.md
@@ -5,3 +5,19 @@ input.
 
 When the stack has been succesfully created/updated the stack output is stored
 in the `stack_outputs` fact, and also written to file.
+
+## Example playbook
+
+```yaml
+- name: Bootstrap infra on Openstack cloud
+  hosts: localhost
+  gather_facts: true
+  strategy: linear
+  roles:
+    - role: heat_stack
+      vars:
+        os_cloud: "{{ os_cloud }}"
+        stack_name: "{{ stack_name }}"
+        stack_template_path: "{{ stack_template_path }}"
+        stack_parameters: "{{ stack_parameters }}"
+```

--- a/roles/heat_stack/tasks/main.yml
+++ b/roles/heat_stack/tasks/main.yml
@@ -19,8 +19,8 @@
     that:
       - stack_name is defined
       - stack_name | length > 0
-      - template_path is defined
-      - template_path | length > 0
+      - stack_template_path is defined
+      - stack_template_path | length > 0
       - controller_ssh_pub_key is defined
       - dataplane_ssh_public_key is defined
 
@@ -29,7 +29,7 @@
     msg:
       cloud: "{{ os_cloud }}"
       name: "{{ stack_name }}"
-      template: "{{ template_path }}"
+      template: "{{ stack_template_path }}"
       parameters: "{{ stack_parameters }}"
 
 - name: Create stack
@@ -37,7 +37,7 @@
     cloud: "{{ os_cloud }}"
     name: "{{ stack_name }}"
     state: present
-    template: "{{ template_path }}"
+    template: "{{ stack_template_path }}"
     parameters: "{{ stack_parameters }}"
     wait: false
 

--- a/scenarios/3-nodes/bootstrap_vars.yml
+++ b/scenarios/3-nodes/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: 3-nodes
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 
 openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
@@ -31,3 +31,20 @@ cinder_volume_pvs:
   - /dev/vde
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  compute_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.large

--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -23,17 +23,17 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_master_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   compute_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      flavor: m1.large
+      flavor: hotstack.large
   router_external_network:
     type: string
     default: public

--- a/scenarios/campus-ha/bootstrap_vars.yml
+++ b/scenarios/campus-ha/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: campus-ha
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 
 ntp_servers: []
@@ -37,3 +37,23 @@ zuul:
   build: 1dcaf86e72ec4400a8012f3892d815be
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  ocp_worker_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  compute_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.large

--- a/scenarios/campus-ha/heat_template.yaml
+++ b/scenarios/campus-ha/heat_template.yaml
@@ -23,22 +23,22 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_master_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   ocp_worker_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   compute_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      flavor: m1.large
+      flavor: hotstack.large
   router_external_network:
     type: string
     default: public

--- a/scenarios/hci/bootstrap_vars.yml
+++ b/scenarios/hci/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: hci
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 test_operator_automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/test-operator/automation-vars.yml"
 
@@ -26,3 +26,20 @@ enable_iscsi: false
 enable_multipath: false
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  compute_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.large

--- a/scenarios/hci/heat_template.yaml
+++ b/scenarios/hci/heat_template.yaml
@@ -23,17 +23,17 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_masters_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   computes_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      flavor: m1.large
+      flavor: hotstack.large
   router_external_network:
     type: string
     default: public

--- a/scenarios/multi-ns/01-infra.yml
+++ b/scenarios/multi-ns/01-infra.yml
@@ -23,12 +23,5 @@
       vars:
         os_cloud: "{{ os_cloud }}"
         stack_name: "{{ stack_name }}"
-        stack_template_path: "{{ template_path }}"
-        stack_parameters:
-          keypair: "{{ os_keypair }}"
-          dns_servers: "{{ dns_servers }}"
-          ntp_servers: "{{ ntp_servers }}"
-          controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
-          dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
-          router_external_network: "{{ os_router_external_network | default('public') }}"
-          floating_ip_network: "{{ os_floating_network | default('public') }}"
+        stack_template_path: "{{ stack_template_path }}"
+        stack_parameters: "{{ stack_parameters }}"

--- a/scenarios/multi-ns/bootstrap_vars.yml
+++ b/scenarios/multi-ns/bootstrap_vars.yml
@@ -8,7 +8,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 scenario: multi-ns
 scenario_dir: scenarios
 
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 test_operator_automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/test-operator/automation-vars.yml"
 
@@ -33,3 +33,21 @@ cinder_volume_pvs:
   - /dev/vde
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  bmh_params:
+    image: CentOS-Stream-GenericCloud-9
+    cd_image: sushy-tools-blank-image
+    flavor: hotstack.medium

--- a/scenarios/multi-ns/heat_template.yaml
+++ b/scenarios/multi-ns/heat_template.yaml
@@ -23,18 +23,18 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_master_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   bmh_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
       cd_image: sushy-tools-blank-image
-      flavor: m1.medium
+      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public

--- a/scenarios/sno-2-bm/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: sno-2-bm
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 test_operator_automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/test-operator/automation-vars.yml"
 
@@ -32,3 +32,21 @@ cinder_volume_pvs:
   - /dev/vde
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  ironics_params:
+    image: CentOS-Stream-GenericCloud-9
+    cd_image: sushy-tools-blank-image
+    flavor: hotstack.medium

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -23,18 +23,18 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_master_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   ironics_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
       cd_image: sushy-tools-blank-image
-      flavor: m1.medium
+      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public

--- a/scenarios/sno-bmh-tests/bootstrap_vars.yml
+++ b/scenarios/sno-bmh-tests/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: sno-bmh-tests
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 test_operator_automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/test-operator/automation-vars.yml"
 
@@ -32,3 +32,21 @@ cinder_volume_pvs:
   - /dev/vde
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  bmh_params:
+    image: CentOS-Stream-GenericCloud-9
+    cd_image: sushy-tools-blank-image
+    flavor: hotstack.medium

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -23,18 +23,18 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_master_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   bmh_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
       cd_image: sushy-tools-blank-image
-      flavor: m1.medium
+      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public

--- a/scenarios/uni01alpha/bootstrap_vars.yml
+++ b/scenarios/uni01alpha/bootstrap_vars.yml
@@ -7,7 +7,7 @@ controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') 
 
 scenario: uni01alpha
 scenario_dir: scenarios
-template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
 automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
 test_operator_automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/test-operator/automation-vars.yml"
 
@@ -32,3 +32,27 @@ cinder_volume_pvs:
   - /dev/vde
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  keypair: "{{ os_keypair }}"
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_public_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge
+  computes_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.large
+  networkers_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.small
+  ironics_params:
+    image: CentOS-Stream-GenericCloud-9
+    cd_image: sushy-tools-blank-image
+    flavor: hotstack.medium

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -23,29 +23,29 @@ parameters:
     type: json
     default:
       image: hotstack-controller
-      flavor: m1.small
+      flavor: hotstack.small
   ocp_masters_params:
     type: json
     default:
       image: ipxe-boot-usb
-      flavor: m1.xxlarge
+      flavor: hotstack.xxlarge
   computes_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      flavor: m1.large
+      flavor: hotstack.large
   networkers_params:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      flavor: m1.small
+      flavor: hotstack.small
   ironics_params:
     type: json
     default:
       # image: ipxe-boot-efi
       image: CentOS-Stream-GenericCloud-9
       cd_image: sushy-tools-blank-image
-      flavor: m1.medium
+      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public


### PR DESCRIPTION
When using different clouds the default values in the heat templates need to be overriden. Flavors, images, floating ip networks etc.

Changes the "01-infra" playbook to use ansible var stack_parameters, and add a stack_parameters section in bootstrap-vars.yml for every scenario.