### PR TITLE
Disble net.ifnames - different clouds ...

### DIFF
--- a/roles/ocp_agent_installer/defaults/main.yml
+++ b/roles/ocp_agent_installer/defaults/main.yml
@@ -48,6 +48,9 @@ multipath_roles:
 enable_iscsi: false
 iscsi_roles:
   - master
+disable_net_ifnames: true
+net_ifnames_roles:
+  - master
 
 # OVN Configuration
 enable_ovn_k8s_overrides: true

--- a/roles/ocp_agent_installer/tasks/machine_configs.yml
+++ b/roles/ocp_agent_installer/tasks/machine_configs.yml
@@ -14,6 +14,23 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Disable net.ifnames
+  when: disable_net_ifnames | bool
+  block:
+    - name: Template butane config for net.ifnames
+      vars:
+        role: "{{ item }}"
+      ansible.builtin.template:
+        src: disable-netifnames.bu.j2
+        dest: "{{ butane_dir }}/90-{{ item }}-disable-netifnames.bu"
+      loop: "{{ net_ifnames_roles }}"
+    - name: Generate MachineConfig for iscsi
+      ansible.builtin.command:
+        cmd: >-
+          butane {{ butane_dir }}/90-{{ item }}-disable-netifnames.bu
+          -o {{ machine_configs_dir }}/90-{{ item }}-disable-netifnames.yaml
+      loop: "{{ net_ifnames_roles }}"
+
 - name: Enable iscsi
   when: enable_iscsi | bool
   block:

--- a/roles/ocp_agent_installer/tasks/pxe_assets.yml
+++ b/roles/ocp_agent_installer/tasks/pxe_assets.yml
@@ -34,6 +34,14 @@
     regexp: "^(kernel.*)$"
     line: '\1 console=ttyS0'
 
+- name: Disable net.ifnames
+  when: disable_net_ifnames | bool
+  ansible.builtin.lineinfile:
+    path: "{{ cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
+    backrefs: true
+    regexp: "^(kernel.*)$"
+    line: '\1 net.ifnames=0'
+
 - name: Copy boot-artifacts to the web server - (boot_artifacts_dir)
   become: true
   ansible.builtin.copy:

--- a/roles/ocp_agent_installer/templates/disable-netifnames.bu.j2
+++ b/roles/ocp_agent_installer/templates/disable-netifnames.bu.j2
@@ -1,0 +1,10 @@
+---
+variant: openshift
+version: 4.17.0
+metadata:
+  name: 90-{{ role | default('master') }}-netifnames-conf
+  labels:
+    machineconfiguration.openshift.io/role: {{ role | default('master') }}
+openshift:
+  kernel_arguments:
+    - net.ifnames=0

--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -556,11 +556,13 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -569,9 +571,10 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
   controller_ansible_host:
     description: >
       Controller ansible host, this struct can be passed to the ansible.builtin.add_host module

--- a/scenarios/3-nodes/manifests/control-plane/networking/nncp.yaml
+++ b/scenarios/3-nodes/manifests/control-plane/networking/nncp.yaml
@@ -28,7 +28,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -44,7 +44,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -60,11 +60,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -72,7 +72,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -92,7 +92,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "23"
     - bridge:
         options:

--- a/scenarios/campus-ha/bootstrap_vars.yml
+++ b/scenarios/campus-ha/bootstrap_vars.yml
@@ -19,6 +19,10 @@ dns_servers:
 pull_secret_file: ~/pull-secret.txt
 
 ovn_k8s_gateway_config_host_routing: true
+net_ifnames_roles:
+  - master
+  - worker
+
 enable_iscsi: true
 iscsi_roles:
   - worker

--- a/scenarios/campus-ha/heat_template.yaml
+++ b/scenarios/campus-ha/heat_template.yaml
@@ -989,13 +989,15 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -1004,19 +1006,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
         - hostname: master-1
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master1-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master1-machine-port, mac_address]}
@@ -1025,19 +1030,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
         - hostname: master-2
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master2-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master2-machine-port, mac_address]}
@@ -1046,19 +1054,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
         - hostname: worker-0
           role: worker
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [worker0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [worker0-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [worker0-machine-port, mac_address]}
@@ -1067,19 +1078,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [worker0-ctlplane-trunk-parent-port, mac_address]}
         - hostname: worker-1
           role: worker
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [worker1-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [worker1-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [worker1-machine-port, mac_address]}
@@ -1088,19 +1102,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [worker1-ctlplane-trunk-parent-port, mac_address]}
         - hostname: worker-2
           role: worker
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [worker2-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [worker2-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [worker2-machine-port, mac_address]}
@@ -1109,9 +1126,10 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [worker2-ctlplane-trunk-parent-port, mac_address]}
 
   controller_ansible_host:
     description: >

--- a/scenarios/hci/heat_template.yaml
+++ b/scenarios/hci/heat_template.yaml
@@ -998,13 +998,15 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth0
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -1013,19 +1015,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
         - hostname: master-1
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master1-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master1-machine-port, mac_address]}
@@ -1034,19 +1039,22 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
         - hostname: master-2
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master2-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master2-machine-port, mac_address]}
@@ -1055,9 +1063,10 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
 
   controller_ansible_host:
     description: >

--- a/scenarios/hci/manifests/control-plane/nncp/nncp.yaml
+++ b/scenarios/hci/manifests/control-plane/nncp/nncp.yaml
@@ -28,7 +28,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -44,7 +44,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -60,11 +60,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -72,7 +72,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -124,7 +124,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -140,7 +140,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -156,11 +156,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -168,7 +168,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -220,7 +220,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -236,7 +236,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -252,11 +252,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -264,7 +264,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:

--- a/scenarios/multi-ns/heat_template.yaml
+++ b/scenarios/multi-ns/heat_template.yaml
@@ -853,11 +853,13 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth0
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -866,12 +868,10 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
-                type: ethernet
-                state: down
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
   controller_ansible_host:
     description: >
       Controller ansible host, this struct can be passed to the ansible.builtin.add_host module

--- a/scenarios/multi-ns/manifests/networking/nncp.yaml
+++ b/scenarios/multi-ns/manifests/networking/nncp.yaml
@@ -23,7 +23,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "10"
     - name: internalapi-a
       type: vlan
@@ -39,7 +39,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - name: storage-a
       type: vlan
@@ -55,7 +55,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - name: tenant-a
       type: vlan
@@ -71,7 +71,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     route-rules:
       config: []
@@ -105,7 +105,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "11"
     - name: internalapi-b
       type: vlan
@@ -121,7 +121,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "30"
     - name: storage-b
       type: vlan
@@ -137,7 +137,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "31"
     - name: tenant-b
       type: vlan
@@ -153,7 +153,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "32"
     route-rules:
       config: []

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -566,11 +566,15 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
+            - name: eth2
+              macAddress: {get_attr: [master0-ironic-port, mac_address]}
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -579,12 +583,14 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
+              - name: eth2
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master0-ironic-port, mac_address]}
   controller_ansible_host:
     description: >
       Controller ansible host, this struct can be passed to the ansible.builtin.add_host module

--- a/scenarios/sno-2-bm/manifests/control-plane/networking/nncp.yaml
+++ b/scenarios/sno-2-bm/manifests/control-plane/networking/nncp.yaml
@@ -28,7 +28,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - name: storage
       type: vlan
@@ -44,7 +44,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - name: tenant
       type: vlan
@@ -60,11 +60,11 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - name: ospbr
@@ -75,7 +75,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       ipv4:
         address:
@@ -95,7 +95,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens5
+        - name: eth2
       ipv4:
         address:
         - ip: 172.20.1.10

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -849,11 +849,13 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -862,12 +864,10 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
-                type: ethernet
-                state: down
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
   controller_ansible_host:
     description: >
       Controller ansible host, this struct can be passed to the ansible.builtin.add_host module

--- a/scenarios/sno-bmh-tests/manifests/control-plane/networking/nncp.yaml
+++ b/scenarios/sno-bmh-tests/manifests/control-plane/networking/nncp.yaml
@@ -28,7 +28,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - name: storage
       type: vlan
@@ -44,7 +44,7 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - name: tenant
       type: vlan
@@ -60,11 +60,11 @@ spec:
       mtu: 1442
       state: up
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - name: ospbr
@@ -75,7 +75,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       ipv4:
         address:

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -1193,13 +1193,17 @@ outputs:
         - hostname: master-0
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master0-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
+            - name: eth2
+              macAddress: {get_attr: [master0-ironic-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master0-machine-port, mac_address]}
@@ -1208,22 +1212,28 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
+                mac-address: {get_attr: [master0-ctlplane-trunk-parent-port, mac_address]}
+              - name: eth2
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master0-ironic-port, mac_address]}
         - hostname: master-1
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master1-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
+            - name: eth2
+              macAddress: {get_attr: [master1-ironic-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master1-machine-port, mac_address]}
@@ -1232,22 +1242,28 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
+                mac-address: {get_attr: [master1-ctlplane-trunk-parent-port, mac_address]}
+              - name: eth2
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master1-ironic-port, mac_address]}
         - hostname: master-2
           role: master
           interfaces:
-            - name: ens3
+            - name: eth0
               macAddress: {get_attr: [master2-machine-port, mac_address]}
+            - name: eth1
+              macAddress: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
+            - name: eth2
+              macAddress: {get_attr: [master2-ironic-port, mac_address]}
           rootDeviceHints:
             deviceName: /dev/vda
           networkConfig:
             interfaces:
-              - name: ens3
+              - name: eth0
                 type: ethernet
                 state: up
                 mac-address: {get_attr: [master2-machine-port, mac_address]}
@@ -1256,12 +1272,14 @@ outputs:
                   dhcp: true
                 ipv6:
                   enabled: false
-              - name: ens4
+              - name: eth1
                 type: ethernet
                 state: down
-              - name: ens5
+                mac-address: {get_attr: [master2-ctlplane-trunk-parent-port, mac_address]}
+              - name: eth2
                 type: ethernet
                 state: down
+                mac-address: {get_attr: [master2-ironic-port, mac_address]}
 
   controller_ansible_host:
     description: >

--- a/scenarios/uni01alpha/manifests/control-plane/nncp/nncp.yaml
+++ b/scenarios/uni01alpha/manifests/control-plane/nncp/nncp.yaml
@@ -28,7 +28,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -44,7 +44,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -60,11 +60,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -72,7 +72,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -92,7 +92,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "23"
     - bridge:
         options:
@@ -109,7 +109,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens5
+        - name: eth2
       description: Ironic bridge
       ipv4:
         address:
@@ -175,7 +175,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -191,7 +191,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -207,11 +207,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -219,7 +219,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -239,7 +239,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "23"
     - bridge:
         options:
@@ -256,7 +256,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens5
+        - name: eth2
       description: Ironic bridge
       ipv4:
         address:
@@ -322,7 +322,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "20"
     - description: storage vlan interface
       ipv4:
@@ -338,7 +338,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "21"
     - description: tenant vlan interface
       ipv4:
@@ -354,11 +354,11 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "22"
     - description: ctlplane interface
       mtu: 1442
-      name: ens4
+      name: eth1
       state: up
       type: ethernet
     - bridge:
@@ -366,7 +366,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens4
+        - name: eth1
           vlan: {}
       description: linux-bridge over ctlplane interface
       ipv4:
@@ -386,7 +386,7 @@ spec:
       state: up
       type: vlan
       vlan:
-        base-iface: ens4
+        base-iface: eth1
         id: "23"
     - bridge:
         options:
@@ -403,7 +403,7 @@ spec:
           stp:
             enabled: false
         port:
-        - name: ens5
+        - name: eth2
       description: Ironic bridge
       ipv4:
         address:


### PR DESCRIPTION
Different cloud's end up using different nameing schemas.

This change adds, and enables by defualt machine config to disable net.ifnames.