### PR TITLE
Add value_specs override for all networks

### DIFF
--- a/scenarios/3-nodes/bootstrap_vars.yml
+++ b/scenarios/3-nodes/bootstrap_vars.yml
@@ -33,6 +33,10 @@ cinder_volume_pvs:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -41,6 +41,9 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
 
 resources:
   #
@@ -50,31 +53,37 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   octavia-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/campus-ha/bootstrap_vars.yml
+++ b/scenarios/campus-ha/bootstrap_vars.yml
@@ -43,6 +43,10 @@ zuul:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/campus-ha/heat_template.yaml
+++ b/scenarios/campus-ha/heat_template.yaml
@@ -46,6 +46,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
+
 
 resources:
   #
@@ -55,41 +59,49 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   machine-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   machine-net-c:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   octavia-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/hci/bootstrap_vars.yml
+++ b/scenarios/hci/bootstrap_vars.yml
@@ -28,6 +28,10 @@ enable_multipath: false
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/hci/heat_template.yaml
+++ b/scenarios/hci/heat_template.yaml
@@ -41,6 +41,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
+
 
 resources:
   #
@@ -50,36 +54,43 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storagemgmt-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   octavia-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/multi-ns/bootstrap_vars.yml
+++ b/scenarios/multi-ns/bootstrap_vars.yml
@@ -35,6 +35,10 @@ cinder_volume_pvs:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/multi-ns/heat_template.yaml
+++ b/scenarios/multi-ns/heat_template.yaml
@@ -42,6 +42,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
+
 
 resources:
   #
@@ -51,63 +55,75 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net-native-vlan:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   # Namespace A Networks
   ctlplane-net-a:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net-a:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net-a:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net-a:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   provisioning-net-a:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   # Namespace B Networks
   ctlplane-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   provisioning-net-b:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/sno-2-bm/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm/bootstrap_vars.yml
@@ -34,6 +34,10 @@ cinder_volume_pvs:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -42,6 +42,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
+
 
 resources:
   #
@@ -51,31 +55,37 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ironic-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/sno-bmh-tests/bootstrap_vars.yml
+++ b/scenarios/sno-bmh-tests/bootstrap_vars.yml
@@ -34,6 +34,10 @@ cinder_volume_pvs:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -42,6 +42,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    default: {}
+
 
 resources:
   #
@@ -51,56 +55,67 @@ resources:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net-0:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net-1:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net-2:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   ctlplane-net-3:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   internal-api-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   storage-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   tenant-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   provisioning-net-0:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   provisioning-net-1:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   provisioning-net-2:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
 
   #
   # Subnets

--- a/scenarios/uni01alpha/bootstrap_vars.yml
+++ b/scenarios/uni01alpha/bootstrap_vars.yml
@@ -34,6 +34,10 @@ cinder_volume_pvs:
 
 stack_name: "hotstack-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
 stack_parameters:
+  # On missconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
   keypair: "{{ os_keypair }}"
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -53,6 +53,10 @@ parameters:
   floating_ip_network:
     type: string
     default: public
+  net_value_specs:
+    type: json
+    defautl: {}
+
 
 resources:
   #


### PR DESCRIPTION
Operating on a cloud with bad configuration, incurrect MTU is causing a massive amount of network traffic fragmentation. Result is 7-8x degraded performance in network transfers, and a magnitude of unnececary CPU load/interupts.

Adding the value_specs, so that the MTU can be forced for the networks to use a better value.

ref: https://access.redhat.com/solutions/7059376