### PR TITLE
Give sushy-emulator route a loong timeout

### DIFF
--- a/roles/redfish_virtual_bmc/templates/route.yaml.j2
+++ b/roles/redfish_virtual_bmc/templates/route.yaml.j2
@@ -2,6 +2,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 60s
   name: sushy-emulator-route
   namespace: sushy-emulator
   labels:

--- a/scenarios/multi-ns/bootstrap_vars.yml
+++ b/scenarios/multi-ns/bootstrap_vars.yml
@@ -51,7 +51,7 @@ stack_parameters:
     flavor: hotstack.small
   ocp_master_params:
     image: ipxe-boot-usb
-    flavor: hotstack.xxlarge
+    flavor: hotstack.xxxlarge
   bmh_params:
     image: CentOS-Stream-GenericCloud-9
     cd_image: sushy-tools-blank-image


### PR DESCRIPTION
Some actions in sushy-emulator can take some time, up the timoutout to avoid returning 504 gateway timeout to the client.