### PR TITLE
Fix issue with scenario doc on `_static` not exist

### DIFF
--- a/scenario-doc/source/conf.py
+++ b/scenario-doc/source/conf.py
@@ -34,4 +34,4 @@ html_theme_options = {
     "globaltoc_maxdepth": 3,
 }
 
-html_static_path = ["_static"]
+# html_static_path = ["_static"]


### PR DESCRIPTION
Building docs started failing, commenting the config fixes the issue.