### PR TITLE
Fix tempest - storageClass

### DIFF
--- a/scenarios/3-nodes/test-operator/tempest-tests.yml
+++ b/scenarios/3-nodes/test-operator/tempest-tests.yml
@@ -7,6 +7,7 @@ metadata:
 spec:
   workflow:
     - stepName: multi-thread-testing
+      storageClass: lvms-local-storage
       tempestconfRun:
         overrides: |
           auth.tempest_roles swiftoperator

--- a/scenarios/multi-ns/test-operator/tempest-tests.yml
+++ b/scenarios/multi-ns/test-operator/tempest-tests.yml
@@ -14,10 +14,10 @@ spec:
       memory: 6Gi
   networkAttachments:
     - ctlplane
-  storageClass: lvms-local-storage
   privileged: true
   workflow:
     - stepName: multi-thread-testing-smoke
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m
@@ -88,10 +88,10 @@ spec:
       memory: 6Gi
   networkAttachments:
     - ctlplane
-  storageClass: lvms-local-storage
   privileged: true
   workflow:
     - stepName: multi-thread-testing-smoke
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m

--- a/scenarios/sno-2-bm/test-operator/tempest-tests.yml
+++ b/scenarios/sno-2-bm/test-operator/tempest-tests.yml
@@ -7,10 +7,10 @@ metadata:
 spec:
   networkAttachments:
     - ctlplane
-  storageClass: lvms-local-storage
   privileged: true
   workflow:
     - stepName: ironic-scenario-testing
+      storageClass: lvms-local-storage
       tempestconfRun:
         create: true
         overrides: |
@@ -35,6 +35,7 @@ spec:
           ^ironic_tempest_plugin.tests.scenario.test_baremetal_basic_ops.BaremetalBasicOps.test_baremetal_server_ops_partition_image
 
     - stepName: ironic-api-testing
+      storageClass: lvms-local-storage
       tempestconfRun:
         create: true
         overrides: |

--- a/scenarios/sno-bmh-tests/test-operator/tempest-tests.yml
+++ b/scenarios/sno-bmh-tests/test-operator/tempest-tests.yml
@@ -7,10 +7,10 @@ metadata:
 spec:
   networkAttachments:
     - ctlplane
-  storageClass: lvms-local-storage
   privileged: true
   workflow:
     - stepName: multi-thread-testing
+      storageClass: lvms-local-storage
       tempestconfRun:
         create: true
         overrides: |

--- a/scenarios/uni01alpha/test-operator/tempest-tests.yml
+++ b/scenarios/uni01alpha/test-operator/tempest-tests.yml
@@ -14,7 +14,6 @@ spec:
       memory: 6Gi
   networkAttachments:
     - ctlplane
-  storageClass: lvms-local-storage
   privileged: true
   tempestRun:
     extraImages:
@@ -30,6 +29,7 @@ spec:
           vcpus: 1
   workflow:
     - stepName: multi-thread-testing
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m
@@ -193,6 +193,7 @@ spec:
           ^whitebox_neutron_tempest_plugin.tests.scenario.test_ovn_fdb.*
           ^whitebox_neutron_tempest_plugin.tests.scenario.test_api_server.*
     - stepName: single-thread-testing
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m
@@ -263,6 +264,7 @@ spec:
         excludeList: |
           ^whitebox_neutron_tempest_plugin.*n
     - stepName: ironic-scenario-testing
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m
@@ -293,6 +295,7 @@ spec:
           ^ironic_tempest_plugin.tests.scenario.test_baremetal_basic_ops.BaremetalBasicOps.test_baremetal_server_ops_partition_image
 
     - stepName: ironic-api-testing
+      storageClass: lvms-local-storage
       resources:
         requests:
           cpu: 2000m


### PR DESCRIPTION
This has worked before, but setting the storageClass in the SPEC no longer works. If I move it to the individual workflow it works.