### PR TITLE
Include SSH key vars in 06-test-operator.yml

### DIFF
--- a/06-test-operator.yml
+++ b/06-test-operator.yml
@@ -12,6 +12,10 @@
     - name: Add controller-0 to the Ansible inventory
       ansible.builtin.add_host: "{{ stack_outputs.controller_ansible_host }}"
 
+    - name: Load dataplane SSH keys vars
+      ansible.builtin.include_vars:
+        file: dataplane_ssh_keys_vars.yaml
+
     - name: Load automation vars
       ansible.builtin.include_vars:
         file: "{{ test_operator_automation_vars_file }}"


### PR DESCRIPTION
Need dataplane SSH public key in kernel_append_params for configuring SSH access to ironic-python-agent.