### PR TITLE
hotstack_work_dir var - use for storing files

### DIFF
--- a/02-bootstrap_controller.yml
+++ b/02-bootstrap_controller.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Load stack output vars from file
       ansible.builtin.include_vars:
-        file: "{{ stack_name }}-outputs.yaml"
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_name }}-outputs.yaml"
         name: stack_outputs
 
   roles:

--- a/03-install_ocp.yml
+++ b/03-install_ocp.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Load stack output vars from file
       ansible.builtin.include_vars:
-        file: "{{ stack_name }}-outputs.yaml"
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_name }}-outputs.yaml"
         name: stack_outputs
 
     - name: Add controller-0 to the Ansible inventory

--- a/04_redfish_virtual_bmc.yml
+++ b/04_redfish_virtual_bmc.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Load stack output vars from file
       ansible.builtin.include_vars:
-        file: "{{ stack_name }}-outputs.yaml"
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_name }}-outputs.yaml"
         name: stack_outputs
 
     - name: Add controller-0 to the Ansible inventory

--- a/05_deploy_rhoso.yml
+++ b/05_deploy_rhoso.yml
@@ -21,7 +21,7 @@
   pre_tasks:
     - name: Load stack output vars from file
       ansible.builtin.include_vars:
-        file: "{{ stack_name }}-outputs.yaml"
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_name }}-outputs.yaml"
         name: stack_outputs
 
     - name: Add controller-0 to the Ansible inventory

--- a/06-test-operator.yml
+++ b/06-test-operator.yml
@@ -10,11 +10,11 @@
         name: stack_outputs
 
     - name: Add controller-0 to the Ansible inventory
-      ansible.builtin.add_host: "{{ stack_outputs.controller_ansible_host }}"
+      ansible.builtin.add_host: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_outputs.controller_ansible_host }}"
 
     - name: Load dataplane SSH keys vars
       ansible.builtin.include_vars:
-        file: dataplane_ssh_keys_vars.yaml
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/dataplane_ssh_keys_vars.yaml"
 
     - name: Load automation vars
       ansible.builtin.include_vars:

--- a/roles/dataplane_ssh_keys/defaults/main.yml
+++ b/roles/dataplane_ssh_keys/defaults/main.yml
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+hotstack_work_dir: "{{ playbook_dir }}"
 dataplane_ssh_key:
   type: rsa
   size: 2048

--- a/roles/dataplane_ssh_keys/tasks/main.yml
+++ b/roles/dataplane_ssh_keys/tasks/main.yml
@@ -51,4 +51,4 @@
       dataplane_ssh_public_key: "{{ _dataplane_ssh_key.public_key }}"
       nova_migration_ssh_private_key_file: "{{ _nova_migration_ssh_key.filename }}"
       nova_migration_ssh_public_key: "{{ _nova_migration_ssh_key.public_key }}"
-    dest: "dataplane_ssh_keys_vars.yaml"
+    dest: "{{ hotstack_work_dir }}/dataplane_ssh_keys_vars.yaml"

--- a/roles/heat_stack/defaults/main.yml
+++ b/roles/heat_stack/defaults/main.yml
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+hotstack_work_dir: "{{ playbook_dir }}"
 os_cloud: "{{ lookup('ansible.builtin.env', 'OS_CLOUD') }}"
 stack_parameters:
   dns_servers:

--- a/roles/heat_stack/tasks/main.yml
+++ b/roles/heat_stack/tasks/main.yml
@@ -73,4 +73,4 @@
 - name: Store stack outputs in file
   ansible.builtin.copy:
     content: "{{ stack_outputs | to_nice_yaml(indent=2) }}"
-    dest: "{{ stack_name }}-outputs.yaml"
+    dest: "{{ hotstack_work_dir }}/{{ stack_name }}-outputs.yaml"


### PR DESCRIPTION
Introduce `hotstack_work_dir` variable in roles `dataplane_ssh_keys` and `heat_stack`. Defaults to `playbook_dir`.