### PR TITLE
Add || /bin/true to hotlog rsync command

### DIFF
--- a/roles/hotlogs/tasks/main.yml
+++ b/roles/hotlogs/tasks/main.yml
@@ -27,4 +27,5 @@
       rsync -avh
         zuul@{{ controller_floating_ip }}:/{{ item }}
           {{ hotlog_dir }}/{{ item | ansible.builtin.basename | ansible.builtin.regex_replace('^[.]', '') }}
+      || /bin/true
   loop: "{{ hotlog_collect_paths }}"


### PR DESCRIPTION
We do not want to fail.