### PR TITLE
Identical stack parameters in all heat templates

### DIFF
--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -20,21 +20,6 @@ parameters:
   keypair:
     type: string
     default: default
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_master_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  compute_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      flavor: hotstack.large
   router_external_network:
     type: string
     default: public
@@ -44,6 +29,45 @@ parameters:
   net_value_specs:
     type: json
     default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+
 
 resources:
   #

--- a/scenarios/campus-ha/heat_template.yaml
+++ b/scenarios/campus-ha/heat_template.yaml
@@ -5,9 +5,6 @@ description: >
   Heat template to set up infrastructure for openstack-k8s-operators uni01alpha example architecture
 
 parameters:
-  keypair:
-    type: string
-    default: default
   dns_servers:
     type: comma_delimited_list
     default:
@@ -20,26 +17,9 @@ parameters:
     type: string
   dataplane_ssh_pub_key:
     type: string
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_master_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  ocp_worker_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  compute_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      flavor: hotstack.large
+  keypair:
+    type: string
+    default: default
   router_external_network:
     type: string
     default: public
@@ -49,6 +29,44 @@ parameters:
   net_value_specs:
     type: json
     default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 
 resources:

--- a/scenarios/hci/heat_template.yaml
+++ b/scenarios/hci/heat_template.yaml
@@ -5,9 +5,6 @@ description: >
   Heat template to set up infrastructure for openstack-k8s-operators HCI example architecture
 
 parameters:
-  keypair:
-    type: string
-    default: default
   dns_servers:
     type: comma_delimited_list
     default:
@@ -20,21 +17,9 @@ parameters:
     type: string
   dataplane_ssh_pub_key:
     type: string
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_masters_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  computes_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      flavor: hotstack.large
+  keypair:
+    type: string
+    default: default
   router_external_network:
     type: string
     default: public
@@ -45,6 +30,43 @@ parameters:
     type: json
     default: {}
 
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 resources:
   #

--- a/scenarios/multi-ns/heat_template.yaml
+++ b/scenarios/multi-ns/heat_template.yaml
@@ -20,22 +20,6 @@ parameters:
   keypair:
     type: string
     default: default
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_master_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  bmh_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      cd_image: sushy-tools-blank-image
-      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public
@@ -46,6 +30,43 @@ parameters:
     type: json
     default: {}
 
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 resources:
   #

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -20,22 +20,6 @@ parameters:
   keypair:
     type: string
     default: default
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_master_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  ironics_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      cd_image: sushy-tools-blank-image
-      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public
@@ -46,6 +30,43 @@ parameters:
     type: json
     default: {}
 
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 resources:
   #

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -20,22 +20,6 @@ parameters:
   keypair:
     type: string
     default: default
-  controller_params:
-    type: json
-    default:
-      image: hotstack-controller
-      flavor: hotstack.small
-  ocp_master_params:
-    type: json
-    default:
-      image: ipxe-boot-usb
-      flavor: hotstack.xxlarge
-  bmh_params:
-    type: json
-    default:
-      image: CentOS-Stream-GenericCloud-9
-      cd_image: sushy-tools-blank-image
-      flavor: hotstack.medium
   router_external_network:
     type: string
     default: public
@@ -45,6 +29,44 @@ parameters:
   net_value_specs:
     type: json
     default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  computes_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networkers_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironics_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 
 resources:

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -5,9 +5,6 @@ description: >
   Heat template to set up infrastructure for openstack-k8s-operators uni01alpha example architecture
 
 parameters:
-  keypair:
-    type: string
-    default: default
   dns_servers:
     type: comma_delimited_list
     default:
@@ -20,12 +17,30 @@ parameters:
     type: string
   dataplane_ssh_pub_key:
     type: string
+  keypair:
+    type: string
+    default: default
+  router_external_network:
+    type: string
+    default: public
+  floating_ip_network:
+    type: string
+    default: public
+  net_value_specs:
+    type: json
+    default: {}
+
   controller_params:
     type: json
     default:
       image: hotstack-controller
       flavor: hotstack.small
   ocp_masters_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
     type: json
     default:
       image: ipxe-boot-usb
@@ -40,22 +55,18 @@ parameters:
     default:
       image: CentOS-Stream-GenericCloud-9
       flavor: hotstack.small
-  ironics_params:
+  bmh_params:
     type: json
     default:
-      # image: ipxe-boot-efi
       image: CentOS-Stream-GenericCloud-9
       cd_image: sushy-tools-blank-image
       flavor: hotstack.medium
-  router_external_network:
-    type: string
-    default: public
-  floating_ip_network:
-    type: string
-    default: public
-  net_value_specs:
+  ironics_params:
     type: json
-    defautl: {}
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
 
 
 resources:


### PR DESCRIPTION
Define all stack paramters in all heat templetes, even if they are not used. This allows to use a common "stack_paramters" input elsewhere.

Avoid, "The Parameter (foo) was not defined in template." errors.