### PR TITLE
Only suport application credential

### DIFF
--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -5,14 +5,9 @@ ssh_key_dir: /home/zuul/.ssh
 cloud_config_dir: /home/zuul/.config/openstack
 data_dir: /home/zuul/data
 hotstack_cloud_secrets:
-  auth_url: http://10.1.200.21:5000
-  username:
-  password:
-  project_name: Default
-  user_domain_name: Default
-  project_domain_name: Default
-  application_credential_id: 38400981a36d4ba0adae425daccb354b
-  application_credential_secret: 5wXr9q9ZY7rjo0pvEQ6otjm586hUgQ322XNlJon6v7GTJXp9L_sV1tQkCQgJ3no1aN89xd-SbsgM7hQ3LhvT-w
+  auth_url: http://cloud.example.com:5000
+  application_credential_id: app_credential_id
+  application_credential_secret: app_credential_secret
   region_name: RegionOne
   interface: public
   identity_api_version: 3

--- a/roles/controller/templates/clouds.yaml.j2
+++ b/roles/controller/templates/clouds.yaml.j2
@@ -6,16 +6,8 @@ clouds:
 {% if hotstack_cloud_secrets.ca_cert_path is defined %}
     cacert: {{ hotstack_cloud_secrets.ca_cert_path }}
 {% endif %}
-    auth_type: {{ hotstack_cloud_secrets.auth_type }}
+    auth_type: v3applicationcredential
     auth:
       auth_url: {{ hotstack_cloud_secrets.auth_url }}
-{% if hotstack_cloud_secrets.auth_type == 'v3password' %}
-      username: {{ hotstack_cloud_secrets.username }}
-      password: {{ hotstack_cloud_secrets.password }}
-      project_name: {{ hotstack_cloud_secrets.project_name }}
-      user_domain_name: {{ hotstack_cloud_secrets.user_domain_name }}
-      project_domain_name: {{ hotstack_cloud_secrets.project_domain_name }}
-{% elif hotstack_cloud_secrets.auth_type == 'v3applicationcredential' %}
       application_credential_id: {{ hotstack_cloud_secrets.application_credential_id }}
       application_credential_secret: {{ hotstack_cloud_secrets.application_credential_secret }}
-{% endif %}


### PR DESCRIPTION
Inside hotstack require application credentail, simplifies the jinja template and reduces hotstack_cloud_secret var.