### PR TITLE
Move clouds yaml

### DIFF
--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -2,8 +2,8 @@
 controller_ansible_host:
 ansible_inventory: {}
 ssh_key_dir: /home/zuul/.ssh
-cloud_config_dir: /home/zuul/.config/openstack
 data_dir: /home/zuul/data
+cloud_config_dir: "/home/zuul/.hotcloud"
 hotstack_cloud_secrets:
   auth_url: http://cloud.example.com:5000
   application_credential_id: app_credential_id

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -105,9 +105,12 @@
       ansible.builtin.file:
         path: "{{ cloud_config_dir }}"
         state: directory
-        mode: '0755'
+        mode: '0750'
+        owner: zuul
+        group: zuul
 
     - name: Template the clouds.yaml
+      no_log: true
       ansible.builtin.template:
         src: clouds.yaml.j2
         dest: >-
@@ -115,6 +118,9 @@
             [cloud_config_dir, 'clouds.yaml']
             | ansible.builtin.path_join
           }}
+        mode: '0640'
+        owner: zuul
+        group: zuul
 
     - name: Write Ironic nodes YAML
       when:

--- a/roles/redfish_virtual_bmc/defaults/main.yml
+++ b/roles/redfish_virtual_bmc/defaults/main.yml
@@ -19,5 +19,5 @@ ingress_domain: apps.ocp.openstack.lab
 redfish_username: admin
 redfish_password: password
 instances_uuids: []
-cloud_config_dir: /home/zuul/.config/openstack
+cloud_config_dir: "/home/zuul/.hotcloud"
 sushy_emulator_manifests: /home/zuul/manifests/sushy_emulator_manifests


### PR DESCRIPTION
The hotstack controller does not need to have the clouds.yaml file in the location where openstackclient would look for it.