### PR TITLE
Allow hotstack controller SSH to dataplane

### DIFF
--- a/scenarios/3-nodes/manifests/edpm/edpm.yaml
+++ b/scenarios/3-nodes/manifests/edpm/edpm.yaml
@@ -69,6 +69,7 @@ spec:
         edpm_nodes_validation_validate_controllers_icmp: false
         edpm_nodes_validation_validate_gateway_icmp: false
         edpm_sshd_allowed_ranges:
+        - 192.168.32.254/32
         - 192.168.122.0/24
         edpm_sshd_configure_firewall: true
         gather_facts: false

--- a/scenarios/multi-ns/manifests/dataplanes/nodesets.yaml
+++ b/scenarios/multi-ns/manifests/dataplanes/nodesets.yaml
@@ -81,6 +81,7 @@ spec:
           {% endfor %}
         edpm_sshd_allowed_ranges:
         - 192.168.122.0/24
+        - 192.168.32.254/32
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: enp4s0
@@ -211,6 +212,7 @@ spec:
           {% endfor %}
         edpm_sshd_allowed_ranges:
         - 192.168.123.0/24
+        - 192.168.32.254/32
         gather_facts: false
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: enp4s0

--- a/scenarios/sno-bmh-tests/manifests/dataplane/nodeset.yaml
+++ b/scenarios/sno-bmh-tests/manifests/dataplane/nodeset.yaml
@@ -76,6 +76,7 @@ spec:
                   routes: {{ lookup('vars', networks_lower[network] ~ '_host_routes') }}
           {% endfor %}
         edpm_sshd_allowed_ranges:
+        - 192.168.32.254/32
         - 192.168.122.0/24
         - 192.168.123.0/24
         - 192.168.124.0/24


### PR DESCRIPTION
Add the IP address of the hotstack controller to `edpm_sshd_allowed_ranges`.