### PR TITLE
Use run_once: true with delegate_to

### DIFF
--- a/03-install_ocp.yml
+++ b/03-install_ocp.yml
@@ -34,6 +34,7 @@
 
   roles:
     - role: ocp_agent_installer
+      run_once: true
       delegate_to: controller-0
       vars:
         install_config: "{{ stack_outputs.ocp_install_config }}"

--- a/05_deploy_rhoso.yml
+++ b/05_deploy_rhoso.yml
@@ -38,6 +38,7 @@
 
   roles:
     - role: hotloop
+      run_once: true
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"

--- a/06-test-operator.yml
+++ b/06-test-operator.yml
@@ -23,6 +23,7 @@
 
   roles:
     - role: hotloop
+      run_once: true
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}/test-operator"

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -24,6 +24,7 @@
   ansible.builtin.add_host: "{{ controller_ansible_host }}"
 
 - name: Block delegated to controller-0
+  run_once: true
   delegate_to: "{{ controller_ansible_host.name }}"
   block:
     - name: Wait for controller-0 to be ready

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -147,6 +147,7 @@ stages:
 
   roles:
     - role: hotloop
+      run_once: true
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"

--- a/roles/ocp_agent_installer/README.md
+++ b/roles/ocp_agent_installer/README.md
@@ -12,6 +12,7 @@ Example:
 
 ```yaml
 - role: ocp_agent_installer
+  run_once: true
   delegate_to: controller-0
   vars:
     install_config: "{{ stack_outputs.ocp_install_config }}"

--- a/roles/redfish_virtual_bmc/tasks/main.yml
+++ b/roles/redfish_virtual_bmc/tasks/main.yml
@@ -77,6 +77,7 @@
       ansible.builtin.include_role:
         name: hotloop
         apply:
+          run_once: true
           delegate_to: controller-0
           vars:
             work_dir: "{{ _tempdir.path }}"

--- a/scenarios/multi-ns/03-install_ocp.yml
+++ b/scenarios/multi-ns/03-install_ocp.yml
@@ -34,6 +34,7 @@
 
   roles:
     - role: ocp_agent_installer
+      run_once: true
       delegate_to: controller-0
       vars:
         install_config: "{{ stack_outputs.ocp_install_config }}"

--- a/scenarios/multi-ns/05-deploy_rhoso.yml
+++ b/scenarios/multi-ns/05-deploy_rhoso.yml
@@ -38,6 +38,7 @@
 
   roles:
     - role: hotloop
+      run_once: true
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"

--- a/scenarios/multi-ns/06-tests.yml
+++ b/scenarios/multi-ns/06-tests.yml
@@ -19,6 +19,7 @@
 
   roles:
     - role: hotloop
+      run_once: true
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}/test-operator"


### PR DESCRIPTION
When delegating tasks to controller-0, also ser `run_once: true`. This removes the "skipped" tasks that otherwise "run" on the host executing the playbook.