### PR TITLE
Brew builds - dataplane

### DIFF
--- a/docs/brew_builds.md
+++ b/docs/brew_builds.md
@@ -3,23 +3,38 @@
 To enable use of not yet published content OpenShift has to be configured to
 do some registry redirection.
 
-> **NOTE:** This work is not complete, only the operators and controlplane will
->           use brew builds. The dataplane nodes will use upstream content.
+**NOTE**: This is **work-in-progress**, in the current state RPM package
+repositories for the dataplane nodes are upstream. The controlplane and
+datplane containers will be pulled from the brew container registries.
+
+## Table of Contents
+
+- [Using brew builds with Hotstack](#using-brew-builds-with-hotstack)
+  - [Table of Contents](#table-of-contents)
+  - [Get brew registry pull-secret](#get-brew-registry-pull-secret)
+  - [Patch you pull-secret to include the brew registry secret](#patch-you-pull-secret-to-include-the-brew-registry-secret)
+  - [Set hotstack variables to enable brew builds](#set-hotstack-variables-to-enable-brew-builds)
+    - [Set variable to create ImageContentSourcePolicy (ICSP)](#set-variable-to-create-imagecontentsourcepolicy-icsp)
+    - [Set image reference for openstack-operators CatalogSource](#set-image-reference-for-openstack-operators-catalogsource)
+    - [Set EDPM container registries](#set-edpm-container-registries)
+    - [Set EDPM container registry logins](#set-edpm-container-registry-logins)
+    - [Set hotstack EDPM bootstrap command variable](#set-hotstack-edpm-bootstrap-command-variable)
 
 ## Get brew registry pull-secret
 
-```
+```shell
 export TESTING_TOKEN_DESCRIPTION="____ REPLACE WITH YOUR OWN DESCRIPTION ____"
 curl --negotiate -u : -X POST -H 'Content-Type: application/json' \
   --data '{"description":"${TESTING_TOKEN_DESCRIPTION}"}' \
-  https://token-manager.registry.example.com/v1/tokens -s > ~/brew-pull-secret.json
+  https://token-manager.registry.example.com/v1/tokens \
+  -s > ~/brew-pull-secret.json
 ```
 
 ## Patch you pull-secret to include the brew registry secret
 
 Include the brew registry secret in the pull-secret.
 
-```
+```shell
 export PULL_SECRET_FILE="~/pull-secret.txt"
 podman login --authfile ${PULL_SECRET_FILE} \
   --username "$(jq -r .credentials.username ~/brew-pull-secret.json)" \
@@ -27,9 +42,21 @@ podman login --authfile ${PULL_SECRET_FILE} \
   brew.registry.redhat.io
 ```
 
-Set the hotstack `pull_secret_file` variable to pont at this pull-secret file.
+Configure the `pull_secret_file` variable in Hotstack to reference the
+generated pull-secret file..
 
-## Set additional variable to create ImageContentSourcePolicy (ICSP)
+## Set hotstack variables to enable brew builds
+
+When executing the hotstack scenario play, it is necessary to add variables.
+These variables, which are detailed in subsequent sections, can be incorporated
+in different ways. For example ...
+
+* Directly add them to the hotstack `bootstrap_vars.yml` file specific to the
+  scenario.
+* Alternatively, use a custom variable file and include it by specifying the
+  option `-e @file.yml` when running the `ansible-playbook` command.
+
+### Set variable to create ImageContentSourcePolicy (ICSP)
 
 An ImageContentSourcePolicy or ICSP describes registry mirroring rules.
 
@@ -59,7 +86,7 @@ image_content_source_policy_mirrors:
     source: proxy.example.com
 ```
 
-## Set image reference for openstack-operators CatalogSource
+### Set image reference for openstack-operators CatalogSource
 
 Override the `openstack_operators_image` and `openstack_operator_channel`
 variables to point at index image for the non-published operator image and
@@ -70,4 +97,50 @@ Example:
 ```yaml
 openstack_operators_image: brew.registry.redhat.io/<namespace>/<image>:<tag>
 openstack_operator_channel: stable-v1.0
+```
+
+### Set EDPM container registries
+
+Customize the dataplane container registries by configuring the
+`edpm_podman_registries` variable. The `edpm_podman_registries` variable is a
+list of registry configurations, where each configuration is a dictionary
+containing the registry's location, insecure flag, and optional mirrors.
+
+Example:
+
+```yaml
+edpm_podman_registries:
+  - prefix: registry.redhat.io
+    insecure: true
+    location: registry.redhat.io
+    mirrors:
+      - location: brew.registry.redhat.io
+        insecure: true
+```
+
+### Set EDPM container registry logins
+
+Customize the dataplane container registries by configuring the
+`edpm_podman_registries` variable. The `edpm_container_registry_logins`
+variable is a dictionary where the keys are the registry locations (e.g.,
+`brew.registry.redhat.io`), and the values are dictionaries containing the
+login credentials (username and password).
+
+Example:
+
+```yaml
+edpm_container_registry_logins:
+   brew.registry.redhat.io:
+     username: password
+```
+
+### Set hotstack EDPM bootstrap command variable
+
+Container images in brew are not signed. The `brew_edpm_bootstrap_command.sh`
+will set "insecureAcceptAnything" policy type so that Podman is allowed to
+accept and run containers from any source, including those signed with unknown
+or self-signed certificates.
+
+```yaml
+hotstack_edpm_bootstrap_command: "{{ scenario_dir }}/common/scripts/brew_edpm_bootstrap_command.sh"
 ```

--- a/roles/hotloop/defaults/main.yml
+++ b/roles/hotloop/defaults/main.yml
@@ -22,3 +22,6 @@ automation:
 
 openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
 openstack_operator_channel: alpha
+
+edpm_podman_registries: []
+edpm_container_registry_logins: {}

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -134,9 +134,19 @@ stages:
       - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
         value: >-
           {{
-            lookup('ansible.builtin.file',
-                   '{{ scenario_dir }}/common/scripts/upstream_edpm_bootstrap_command.sh')
+            lookup('ansible.builtin.file', hotstack_edpm_bootstrap_command)
           }}
+      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+        value: "{{ edpm_podman_registries }}"
+        where:
+          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+            value: null
+      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
+        value: "{{ edpm_container_registry_logins }}"
+        where:
+          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+            value: null
+
     wait_conditions:
       - >-
         oc -n openstack wait openstackdataplanenodeset openstack-edpm

--- a/scenarios/3-nodes/bootstrap_vars.yml
+++ b/scenarios/3-nodes/bootstrap_vars.yml
@@ -14,6 +14,8 @@ openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-in
 openstack_operator_channel: alpha
 openshift_version: stable-4.18
 
+hotstack_edpm_bootstrap_command: "{{ scenario_dir }}/common/scripts/upstream_edpm_bootstrap_command.sh"
+
 ntp_servers: []
 dns_servers:
   - 8.8.8.8

--- a/scenarios/common/scripts/brew_edpm_bootstrap_command.sh
+++ b/scenarios/common/scripts/brew_edpm_bootstrap_command.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+mkdir -p /root/.config/containers/
+
+cat << EOF > /root/.config/containers/policy.json
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ]
+}
+EOF
+
+# TODO(hjensas): This uses upstream for packages, must switch to downstream.
+pushd /var/tmp
+
+curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+
+pushd repo-setup-main
+
+python3 -m venv ./venv
+PBR_VERSION=0.0.0 ./venv/bin/pip install ./
+
+# This is required for FIPS enabled until trunk.rdoproject.org
+# is not being served from a centos7 host, tracked by
+# https://issues.redhat.com/browse/RHOSZUUL-1517
+update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+
+./venv/bin/repo-setup current-podified -b antelope
+
+popd
+
+rm -rf repo-setup-main


### PR DESCRIPTION
Patch the following paths in the nodeset:
- spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
- spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins

Patched with values from variables `edpm_podman_registries` and
`edpm_container_registry_logins`. By default both variables are defined
"empty". When using brew builds, the user must set these variables to
define the custom registries and login details.

Also add a brew_edpm_bootstrap_command.sh script that set podman policy
to allow insecure registries.