### PR TITLE
Add `patches` support in hotloop role

### DIFF
--- a/docs/hotloop_lang.md
+++ b/docs/hotloop_lang.md
@@ -1,31 +1,89 @@
 <!-- An AI Assistent was used to write this document -->
-## Hotloop - Pipeline Structured Language Documentation
+# Hotloop - Pipeline Structured Language Documentation
 
-This document explains the structured language used to define the Hotloop pipeline. The pipeline is organized into a series of **stages**, each representing a distinct phase in the deployment or configuration process.
+This document explains the structured language used to define the Hotloop
+pipeline. The pipeline is organized into a series of **stages**, each
+representing a distinct phase in the deployment or configuration process.
 
-### Stages
+## Stages
 
-A **stage** is a logical unit within the CI pipeline that performs a specific set of actions. Each stage has a `name` for identification and can optionally include a `documentation` field to provide a human-readable description of its purpose. Stages are executed sequentially in the order they are defined in the YAML document.
+A **stage** is a logical unit within the CI pipeline that performs a specific
+set of actions. Each stage has a `name` for identification and can optionally
+include a `documentation` field to provide a human-readable description of its
+purpose. Stages are executed sequentially in the order they are defined in the
+YAML document.
 
-By organizing the pipeline into these stages and utilizing the different stage types, the CI process becomes modular, readable, and maintainable. Each stage focuses on a specific task, making it easier to understand the overall workflow and to troubleshoot any potential issues.
+By organizing the pipeline into these stages and utilizing the different stage
+types, the CI process becomes modular, readable, and maintainable. Each stage
+focuses on a specific task, making it easier to understand the overall
+workflow and to troubleshoot any potential issues.
 
 Here's a breakdown of the common attributes within a stage:
 
-* **`name`**: (Required) A unique identifier for the stage. This name is typically used for logging and monitoring purposes.
-* **`documentation`**: (Optional) A multi-line string providing a detailed explanation of what the stage does, its context, and any important considerations. This is helpful for understanding the pipeline's flow and the purpose of each step.
-* **`manifest`**: (Optional) Specifies the path to a YAML manifest file that will be applied to the target environment (e.g., an OpenShift cluster using `oc apply -f`). This is commonly used for deploying Kubernetes or OpenShift resources.
-* **`j2_manifest`**: (Optional) Specifies the path to a Jinja2 template file that will be rendered into a YAML manifest and then applied to the target environment. This is useful for creating dynamic configurations based on variables.
-* **`cmd`**: (Optional) Defines a single command-line instruction to be executed on the pipeline runner. This is suitable for simple tasks like labeling nodes or triggering external scripts.
-* **`script`**: (Optional) Defines a script that will be executed on the pipeline runner. This is useful for more complex logic or sequences of commands.
-* **`wait_conditions`**: (Optional) A list of commands that are executed to wait for a specific condition to be met in the target environment. These are typically `oc wait` commands in the context of OpenShift, ensuring that resources are created, become ready, or reach a desired state before the pipeline proceeds. Each item in the list is a command-line string.
+* **`name`**: (Required) A unique identifier for the stage.
+  This name is typically used for logging and monitoring purposes.
+* **`documentation`**: (Optional) A multi-line string providing a detailed
+  explanation of what the stage does, its context, and any important
+  considerations. This is helpful for understanding the pipeline's flow and
+  the purpose of each step.
+* **`manifest`**: (Optional) Specifies the path to a YAML manifest file that
+  will be applied to the target environment (e.g., an OpenShift cluster using
+  `oc apply -f`). This is commonly used for deploying Kubernetes or OpenShift
+  resources.
+* **`j2_manifest`**: (Optional) Specifies the path to a Jinja2 template file
+  that will be rendered into a YAML manifest and then applied to the target
+  environment. This is useful for creating dynamic configurations based on
+  variables.
+* **`patches`** (Optional): A list of YAML patches to apply to `manifests` and/or `j2_manifests`.
+  * Each patch must define:
+    * `path`: The location in the YAML data for replacement.
+    * `value`: The new value to replace the existing one.
+  * A patch can optionally include a list of `where` conditions.
+    * Each `where` condition requires:
+      * `path`: The specific location within the YAML data to evaluate.
+      * `value`: The value to compare against at the specified path.
+  * Jinja2 manifests are templated first, then patches are applied.
+  * The `value` replaces the current value, no merge.
+  * Patches apply to all YAML documents in the file with the specified path.
+  * An error is raised if no YAML document in the file has the specified path.
 
-### Stage Types
+  **Example patch:**
 
-The pipeline utilizes different stage types to perform various actions. Here's a detailed explanation of each type:
+    ```yaml
+    - path: "spec.dns.template.options.[0].values"
+      value:
+        - 192.168.32.250
+        - 192.168.32.251
+      where:
+        - path: kind
+          value: OpenStackControlPlane
+        - path: metadata.namespace
+          value: openstack-b
+    ```
 
-#### 1. `cmd` Stage
+* **`cmd`**: (Optional) Defines a single command-line instruction to be
+  executed on the pipeline runner. This is suitable for simple tasks like
+  labeling nodes or triggering external scripts.
+* **`script`**: (Optional) Defines a script that will be executed on the
+  pipeline runner. This is useful for more complex logic or sequences of
+  commands.
+* **`wait_conditions`**: (Optional) A list of commands that are executed to
+  wait for a specific condition to be met in the target environment. These
+  are typically `oc wait` commands in the context of OpenShift, ensuring that
+  resources are created, become ready, or reach a desired state before the
+  pipeline proceeds. Each item in the list is a command-line string.
 
-The `cmd` stage type executes a single command-line instruction. It's straightforward and suitable for simple, direct actions on the system where the pipeline is running or against a configured target environment (like an OpenShift cluster via `oc`).
+## Stage Types
+
+The pipeline utilizes different stage types to perform various actions. Here's
+a detailed explanation of each type:
+
+### 1. `cmd` Stage
+
+The `cmd` stage type executes a single command-line instruction. It's
+straightforward and suitable for simple, direct actions on the system where
+the pipeline is running or against a configured target environment (like an
+OpenShift cluster via `oc`).
 
 **Example:**
 
@@ -34,50 +92,100 @@ The `cmd` stage type executes a single command-line instruction. It's straightfo
   cmd: oc label node master-0 vrf=true
 ```
 
-In this example, the cmd stage executes the oc label node master-0 vrf=true command to label a node named master-0 with the key vrf and value true.
+In this example, the cmd stage executes the oc label node master-0 vrf=true
+command to label a node named master-0 with the key vrf and value true.
 
-#### 2. `script` Stage
+### 2. `script` Stage
 
-The `script` stage type executes a script. This allows for more complex logic and a sequence of commands to be performed within a single stage. The script attribute would specify a multiline string.
+The `script` stage type executes a script. This allows for more complex logic
+and a sequence of commands to be performed within a single stage. The script
+attribute would specify a multiline string.
 
 **Example:**
+
 ```yaml
 - name: Set a multiattach volume type and create it if needed
   script: |
     set -xe -o pipefail
     oc project openstack
 
-    oc rsh openstackclient openstack volume type show multiattach &>/dev/null || \
-      oc rsh openstackclient openstack volume type create multiattach
+    oc rsh openstackclient \
+      openstack volume type show multiattach &>/dev/null || \
+        oc rsh openstackclient openstack volume type create multiattach
 
-    oc rsh openstackclient openstack volume type set --property multiattach="<is> True" multiattach
+    oc rsh openstackclient \
+      openstack volume type set --property multiattach="<is> True" multiattach
 ```
 
-#### 3. `manifest` Stage
+### 3. `manifest` Stage
 
-The `manifest` stage type applies a YAML manifest file to the target environment. This is the primary way to deploy and configure Kubernetes or OpenShift resources defined in static YAML files. The manifest attribute specifies the path to the YAML file.
+The `manifest` stage type applies a YAML manifest file to the target
+environment. This is the primary way to deploy and configure Kubernetes or
+OpenShift resources defined in static YAML files. The manifest attribute
+specifies the path to the YAML file.
+
+In addition to applying the manifest, the `patches` attribute allows you to
+modify the YAML data before deployment. Patches are replacing the current
+values at the specified paths without merging. This enables you to update and
+customize the manifest content dynamically.
 
 **Example:**
+
 ```yaml
-- name: Common MetalLB
-  manifest: "{{ common_dir }}/metallb.yaml"
+- name: Openstack Controlplane
+  manifest: "openstack_controlplane.yaml"
+  patches:
+    - path: "spec.dns.template.options.[0].values"
+        value:
+          - 192.168.32.250
+          - 192.168.32.251
   wait_conditions:
-    - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+    - >-
+      oc wait -n metallb-system pod -l component=speaker --for condition=Ready
+      --timeout=300s"
 ```
 
-Here, the `manifest` stage applies the YAML file located at `{{ common_dir }}/metallb.yaml`. The `wait_conditions` then ensure that the MetalLB speaker pods become ready before the pipeline moves to the next stage.
+Here, the `manifest` stage applies the YAML file located at
+`openstack_controlplane.yaml`. The `wait_conditions` then ensure that the
+MetalLB speaker pods become ready before the pipeline moves to the next stage.
 
-#### 4. `j2_manifest` Stage
+### 4. `j2_manifest` Stage
 
-The `j2_manifest` stage type renders a Jinja2 template file into a YAML manifest and then applies the resulting YAML to the target environment. This is powerful for creating dynamic configurations where values are injected into the YAML based on variables or context. The `j2_manifest` attribute specifies the path to the Jinja2 template file.
+The `j2_manifest` stage type renders a Jinja2 template file into a YAML
+manifest and then applies the resulting YAML to the target environment. This
+is powerful for creating dynamic configurations where values are injected into
+the YAML based on variables or context. The `j2_manifest` attribute specifies
+the path to the Jinja2 template file.
+
+In addition to applying the manifest, the `patches` attribute allows you to
+modify the YAML data before deployment. Patches are applied after Jinja2
+templating, replacing the current values at the specified paths without
+merging. This enables you to update and customize the manifest content
+dynamically.
 
 **Example:**
+
 ```yaml
 - name: Common OLM
   j2_manifest: "{{ common_dir }}/olm.yaml.j2"
+  patches:
+    - where:
+        - path: kind
+          value: Subscription
+        - path: metadata.name
+          value: openstack-operator
+        - path: metadata.namespace
+          value: openstack-operators
+      path: "spec.channel"
+      value: "stable-v1.0"
   wait_conditions:
-    - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - >-
+      oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active'
+      --timeout=300s
     # ... other wait conditions ...
 ```
 
-In this example, the `olm.yaml.j2` Jinja2 template is rendered, and the resulting YAML is applied. The `wait_conditions` then verify the successful creation and readiness of the involved kubernetes resources like namespaces, operator groups, catalog sources, subscriptions etc.
+In this example, the `olm.yaml.j2` Jinja2 template is rendered, and the
+resulting YAML is applied. The `wait_conditions` then verify the successful
+creation and readiness of the involved kubernetes resources like namespaces,
+operator groups, catalog sources, subscriptions etc.

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -23,6 +23,22 @@ Schema for a stage item is:
   * **Currently only used for operator image and channel, extensive usage discurraged.**
   * If both a static and dynamic manifest is defined in the same stage, the
     static one is applied first - then the dynamic (Jinja2) manifest is applied
+    and patches are applied to both manifest and j2_manifest.
+* `patches`: (list) List of YAML patches to apply to `manifests` and/or `j2_manifests`.
+  * Each patch must define the `path` and the `value` to replace at the path.
+  * Jinja2 manifests are templated first, then patches are applied.
+  * The value in the patch replaces the current value, e.g. **no** merge.
+  * Patches are applied to all YAML documents in the file where the path exist.
+  * An error is reised if no YAML document in the manifest file has the path
+    specified in the patch.
+  * Example patch:
+    ```yaml
+    patches:
+      - path: "spec.dns.template.options.[0].values"
+        value:
+          - 192.168.32.250
+          - 192.168.32.251
+    ```
 * `wait_conditions` (list) A list of commands to run after applying the
   manifest, i.e `oc wait --for <condition>`
 

--- a/roles/hotloop/tasks/static_manifest.yml
+++ b/roles/hotloop/tasks/static_manifest.yml
@@ -25,6 +25,7 @@
       }}
     state: directory
     mode: '0755'
+
 - name: "Stage: {{ item.name }} :: Copy manifest"
   ansible.builtin.copy:
     src: >-
@@ -42,6 +43,25 @@
           item.manifest | ansible.builtin.basename
         ] | ansible.builtin.path_join
       }}
+
+- name: "Stage: {{ item.name }} :: Apply patches"
+  when: item.patches is defined
+  hotloop_yaml_patch:
+    file: >-
+      {{
+        [
+          manifests_dir,
+          item.manifest | dirname | ansible.builtin.basename,
+          item.manifest | ansible.builtin.basename
+        ] | ansible.builtin.path_join
+      }}
+    path: "{{ __patch.path }}"
+    value: "{{ __patch.value }}"
+  loop: "{{ item.patches }}"
+  loop_control:
+    label: "{{ __patch.path }}"
+    loop_var: __patch
+
 - name: "Stage: {{ item.name }} :: Apply static manifest"
   ansible.builtin.command:
     chdir: "{{ manifests_dir }}"

--- a/roles/hotloop/tasks/template_manifest.yml
+++ b/roles/hotloop/tasks/template_manifest.yml
@@ -25,6 +25,7 @@
       }}
     state: directory
     mode: '0755'
+
 - name: "Stage: {{ item.name }} :: Template manifest"
   ansible.builtin.template:
     src: >-
@@ -42,6 +43,25 @@
           item.j2_manifest | ansible.builtin.basename | ansible.builtin.splitext | first
         ] | ansible.builtin.path_join
       }}
+
+- name: "Stage: {{ item.name }} :: Apply patches"
+  when: item.patches is defined
+  hotloop_yaml_patch:
+    file: >-
+      {{
+        [
+          manifests_dir,
+          item.j2_manifest | dirname | ansible.builtin.basename,
+          item.j2_manifest | ansible.builtin.basename
+        ] | ansible.builtin.path_join
+      }}
+    path: "{{ __patch.path }}"
+    value: "{{ __patch.value }}"
+  loop: "{{ item.patches }}"
+  loop_control:
+    label: "{{ __patch.path }}"
+    loop_var: __patch
+
 - name: "Stage: {{ item.name }} :: Apply dynamic manifest (Jinja2)"
   ansible.builtin.command:
     chdir: "{{ manifests_dir }}"


### PR DESCRIPTION
Add tasks in static_manifest.yml and template_manifest.yml to loop over patches in the stage.

Example:
```yaml
- name: EDPM nodeset
  manifest: manifests/edpm/edpm.yaml
  patches:
    - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
      value: >-
        {{
          lookup('ansible.builtin.file',
                 '../common/scripts/upstream_edpm_bootstrap_command.sh')
        }}
```