### PR TITLE
Add wait for metallb service's

### DIFF
--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -44,6 +44,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -31,6 +31,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -77,6 +77,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/sno-2-bm/automation-vars.yml
+++ b/scenarios/sno-2-bm/automation-vars.yml
@@ -69,6 +69,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -77,6 +77,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -69,6 +69,9 @@ stages:
       - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
       - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+      - >-
+        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
+        --for jsonpath='{.status.loadBalancer}' --timeout=300s
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=


### PR DESCRIPTION
Seeing occationally:
```
Error from server (InternalError): error when creating "/home/zuul/manifests/common/metallb.yaml": Internal error occurred: failed calling webhook "metallbvalidationwebhook.metallb.io": failed to call webhook: Post "https://metallb-operator-controller-manager-service.metallb-system.svc:443/validate-metallb-io-v1beta1-metallb?timeout=10s": no endpoints available for service "metallb-operator-controller-manager-service"
```