### PR TITLE
Improve "approve install plan"

### DIFF
--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -50,14 +50,14 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/common/scripts/approve_install_plan.sh.j2
+++ b/scenarios/common/scripts/approve_install_plan.sh.j2
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+SUBSCRIPTION_STATE=$(oc -n openstack-operators get subscriptions.operators.coreos.com \
+                     openstack-operator -o jsonpath='{ .status.state }')
+if [ "${SUBSCRIPTION_STATE}" == "AtLatestKnown" ]; then
+    exit 0
+fi
+
+INSTALLED_CSV=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
+                -o jsonpath='{ .status.installedCSV }')
+
+if [ -n "$INSTALLED_CSV" ]; then
+    exit 0
+fi
+
+INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com \
+               openstack-operator -o jsonpath='{ .status.installPlanRef.name }')
+
+oc -n openstack-operators patch installplans.operators.coreos.com \
+    "${INSTALL_PLAN}" -p '{"spec":{"approved":true}}' --type merge

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -37,18 +37,19 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
         --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
 
   - name: Patch openstack leader election tuneables
     script: >-

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -83,18 +83,19 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
         --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
 
   - name: Patch openstack leader election tuneables
     script: >-

--- a/scenarios/sno-2-bm/automation-vars.yml
+++ b/scenarios/sno-2-bm/automation-vars.yml
@@ -75,14 +75,14 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -83,18 +83,19 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
         --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
 
   - name: Patch openstack leader election tuneables
     script: >-

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -75,18 +75,19 @@ stages:
       - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
       - >-
         oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for condition=InstallPlanPending --timeout=300s
+        --for jsonpath='{.status.state}' --timeout=300s
 
   - name: Approve openstack-operator Install plan
-    script: |
-      INSTALL_PLAN=$(oc -n openstack-operators get subscriptions.operators.coreos.com openstack-operator \
-                     -o jsonpath='{ .status.installPlanRef.name }')
-      oc -n openstack-operators patch installplans.operators.coreos.com "${INSTALL_PLAN}" \
-        -p '{"spec":{"approved":true}}' --type merge
+    script: >-
+      {{
+        lookup('ansible.builtin.template',
+               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh.j2')
+      }}
     wait_conditions:
       - >-
         oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
         --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
 
   - name: Patch openstack leader election tuneables
     script: >-


### PR DESCRIPTION
Make it improve only the first plan i.e `startingCSV` plan even if the hotloop stages are re-run.