### PR TITLE
hotloop stage loader - nested stages

### DIFF
--- a/docs/hotloop_lang.md
+++ b/docs/hotloop_lang.md
@@ -72,8 +72,8 @@ Here's a breakdown of the common attributes within a stage:
   are typically `oc wait` commands in the context of OpenShift, ensuring that
   resources are created, become ready, or reach a desired state before the
   pipeline proceeds. Each item in the list is a command-line string.
-* **`run_conditions`**: (Optional) A list of conditions that must be met for a stage
-  to execute. Each condition has a `name` and a `condition` field.
+* **`run_conditions`**: (Optional) A list of conditions that must be met for a
+  stage to execute. Each condition has a `name` and a `condition` field.
   * `name`: A human-readable string that describes the condition. This helps
     in understanding the purpose of the condition when reviewing the
     automation workflow.
@@ -99,7 +99,42 @@ Here's a breakdown of the common attributes within a stage:
             openstack_operators_starting_csv is version('v1.0.6', '>')
           }}
     ```
+* **`stages`**: (Optional) This parameter allows you to define nested stages.
+  By utilizing nested stages, you can create more modular and reusable
+  automation workflows.
 
+  You can load stages from external YAML files using Ansible's `lookup()`
+  function. This is particularly useful for managing large numbers of stages
+  or stages that are shared across multiple scenarios.
+
+  You can also define nested stages directly within the main stage either
+  using YAML's block scalar syntax (`|>`), os as a `dict` or `list`. This is
+  useful for including a small number of stages inline in combinetion with
+  `run_conditions`.
+
+  By setting `run_conditions` on a stage with nested stages, you can
+  conditionally include or exclude the nested stages based on specific
+  criteria. This allows for more dynamic and flexible automation workflows.
+
+  > **NOTE**: Nested stages are not allowed to have their own nested stages.
+
+  **Example nested stages**:
+  ```yaml
+  - name: Include stages from file
+    stages: >-
+      {{
+        lookup('ansible.builtin.file', 'extra_stages.yaml')
+      }}
+  - name: Include stages inline as "list"
+    stages:
+      - name: Extra inline stage - cmd
+        cmd: uname -a
+      - name: Extra inline stage - manifest
+        manifest: "manifest.yaml"
+    run_conditions:
+      - name: extra stages are enabled
+        condition: "{{ extra_stages is defined and extra_stages }}"
+  ```
 
 ## Stage Types
 

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -82,9 +82,31 @@ Schema for a stage item is:
             openstack_operators_starting_csv is version('v1.0.6', '>')
           }}
     ```
+* `stages`: (dict, list or YAML string) Nested stages, enable referencing
+  stages inline or loading stages from different files by utilizing ansible
+  `lookup()`.
+
+  By setting `run_conditions` on a stage with nested stages it is also
+  possible to conditionally include/exclude stages.
+
+  > **NOTE**: Nested stages are not allowed to have their own nested stages.
+
+  **Example stage including nested stages**:
+  ```yaml
+  - name: Include stages from template
+    stages: >-
+      {{
+        lookup('ansible.builtin.template', 'extra_stages.yaml.j2')
+      }}
+    run_conditions:
+      - name: extra stages is defined
+        condition: "{{ extra_stages is defined and extra_stages }}"
+  ```
+
 
 > **_NOTE_**: Stage items are applied the actions in the following order:
-> `cmd` -> `script` -> `manifest` -> `j2_manifest` -> `wait_conditions`.
+> `cmd` -> `script` -> `manifest` -> `j2_manifest` -> `wait_conditions` ->
+> `stages`.
 
 Example:
 ```yaml

--- a/roles/hotloop/library/hotloop_stage_loader.py
+++ b/roles/hotloop/library/hotloop_stage_loader.py
@@ -1,0 +1,241 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+
+DOCUMENTATION = r"""
+---
+module: hotloop_stage_loader
+
+short_description: Loads hotloop stages and nested stages
+
+version_added: "2.8"
+
+description:
+    - |
+      Load and validate hotloop stages and nested stages.
+
+      It accepts a list of stages as input, processes them, and returns
+      a list of validated and loaded stages.
+
+options:
+  stages:
+    description:
+      - A list of stages to load
+    type: list
+author:
+    - Harald Jensås <hjensas@redhat.com>
+"""
+
+EXAMPLES = r"""
+- name: Load hotloop stages
+  hotloop_stage_loader:
+    stages:
+      - name: Stage 1
+        script: |
+          echo "Hello Earth!"
+        stages: |
+          ---
+          stages:
+            - name: An inline nested stage
+              script: |
+                echo "Hello Mars!"
+          ---
+          stages:
+            - name: Another inline nested stage
+              script: |
+                echo "Hello Venus!"
+      - name: Nested stages from jinja2 template
+        stages: >-
+          {{
+            lookup('ansible.builtin.template', 'automation-vars2.yaml.j2')
+          }}
+      - name: Stage 2
+        script: |
+          echo "Hello Saturne!"
+      - name: Nested stages from file
+        script: |
+          echo "Hello Jupiter!"
+        stages: >-
+          {{
+            lookup('ansible.builtin.file', 'automation-vars3.yaml')
+          }}
+"""
+
+RETURN = r"""
+stages: []
+"""
+
+
+def _load_nested(stages):
+    """Load and validates nested stages
+
+    :param stages: (str, list or dict) Containing stages.
+        If it is a string, it must be a YAML string containing stages
+    :returns: (list) A list of stages
+    :raises: TypeError: If the stages are invalid
+    """
+    result = []
+
+    if isinstance(stages, str):
+        stages = yaml.safe_load(stages)
+
+    if isinstance(stages, dict):
+        stages = stage.get("stages", [])
+    elif isinstance(stages, list):
+        pass
+    else:
+        raise TypeError(
+            "nested stages must be a YAML string, list or dict, {stages}".format(
+                stages=type(stages)
+            )
+        )
+
+    for stage in stages:
+
+        # Validate the current stage
+        _validate_stage(stage, nested=True)
+
+        result.append(stage)
+
+    return result
+
+
+def _evaluate_conditions(run_conditions):
+    if run_conditions is None:
+        return True
+
+    for run_condition in run_conditions:
+        if not bool(run_condition["condition"]):
+            return False
+
+    return True
+
+
+def _validate_run_conditions(conditions):
+    if not isinstance(conditions, list):
+        raise TypeError(
+            "'run_conditions' must be a list, {conditions}".format(
+                conditions=type(conditions)
+            )
+        )
+    for cond in conditions:
+        if not isinstance(cond, dict):
+            raise TypeError(
+                "'run_conditions' must be a list of dicts, {cond}".format(
+                    cond=type(cond)
+                )
+            )
+        if "name" not in cond or "condition" not in cond:
+            raise ValueError(
+                "'name' or 'condition' is missing from run_condition {cond}".format(
+                    cond=cond
+                )
+            )
+
+
+def _validate_stage(stage, nested=False):
+    """Validate a stage
+
+    :param stage: The stage to validate
+    :raises ValueError: If the stage is invalid
+    """
+    if not isinstance(stage, dict):
+        raise ValueError("All stages must be a dict, {stage}".format(stage=type(stage)))
+
+    if "name" not in stage:
+        raise ValueError("All stages must have a name, {stage}".format(stage=stage))
+
+    if nested and "stages" in stage:
+        raise ValueError("Nested stages cannot be nested, {stage}".format(stage=stage))
+
+    if "run_conditions" in stage:
+        _validate_run_conditions(stage["run_conditions"])
+
+
+def _load_stages(stages):
+    """Loads and validates a list of stages.
+
+    This function processes a list of stages, validating each one
+    and handling nested stages.
+
+    :param stages: (list) A list of stages to load.
+    :returns: (list) A list of validated and loaded stages.
+    :raises TypeError: If the stages parameter is not a list
+    """
+    if not isinstance(stages, list):
+        raise TypeError(
+            "Stages must be a list, got {stages}".format(stages=type(stages))
+        )
+
+    loaded = []
+
+    for stage in stages:
+        # Validate the current stage
+        _validate_stage(stage)
+
+        # Extract nested stages if they exist
+        nested = stage.pop("stages", None)
+
+        # If the stage has more than one key, it's a top-level stage
+        if len(stage.keys()) > 1:
+            loaded.append(stage)
+
+        conditions = stage.get("run_conditions", None)
+
+        # If there are nested stages, load them
+        if nested and _evaluate_conditions(conditions):
+            loaded.extend(_load_nested(nested))
+
+    return loaded
+
+
+def run_module():
+    argument_spec = yaml.safe_load(DOCUMENTATION)["options"]
+    module = AnsibleModule(argument_spec, supports_check_mode=False)
+    result = dict(success=False, changed=False, error="", outputs=dict(stages=[]))
+    stages = module.params["stages"]
+
+    try:
+        result["outputs"]["stages"] = _load_stages(stages)
+    except Exception as err:
+        # If an error occurs, set the error message and fail the module
+        result["error"] = str(err)
+        result["msg"] = "Unable to load stages: {stages}".format(stages=stages)
+        module.fail_json(**result)
+
+    # Set the changed and success flags in the result dictionary and exit the module
+    result["changed"] = True
+    result["success"] = True
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/hotloop/tasks/execute_stage.yml
+++ b/roles/hotloop/tasks/execute_stage.yml
@@ -18,9 +18,9 @@
   ansible.builtin.assert:
     quiet: true
     that:
-      - __item.condition | bool
-    fail_msg: "Stage run condition: {{ __item.name }} evaluated:  {{ __item.condition | bool }}"
-    success_msg: "Stage run condition: {{ __item.name }} evaluated: {{ __item.condition | bool }}"
+      - __item.condition
+    fail_msg: "Stage run condition: {{ __item.name }} evaluated:  {{ __item.condition }}"
+    success_msg: "Stage run condition: {{ __item.name }} evaluated: {{ __item.condition }}"
   loop: "{{ item.run_conditions | default([]) }}"
   loop_control:
     loop_var: __item

--- a/roles/hotloop/tasks/main.yml
+++ b/roles/hotloop/tasks/main.yml
@@ -33,7 +33,12 @@
   loop:
     - "{{ manifests_dir }}"
 
+- name: Load stages
+  hotloop_stage_loader:
+    stages: "{{ automation.stages }}"
+  register: __loaded_stages
+
 - name: Execute automation stages
   ansible.builtin.include_tasks:
     file: execute_stage.yml
-  loop: "{{ automation.stages }}"
+  loop: "{{ __loaded_stages.outputs.stages }}"


### PR DESCRIPTION
Add `hotloop_stage_loader.py` module to hotloop role.

Module loads stages and nested stages to build a single list of stages for hotloop to execute.

This will allow for a more modular approach, where common stages cane be included from other files via ansible `lookup()` (file or template).