### PR TITLE
Bump disk from 160G to 200G (xxlarge and xxxlarge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ bootstrap variable files.
 openstack flavor create hotstack.small   --public --vcpus  1 --ram  2048 --disk  20
 openstack flavor create hotstack.medium  --public --vcpus  2 --ram  4096 --disk  40
 openstack flavor create hotstack.large   --public --vcpus  4 --ram  8192 --disk  80
-openstack flavor create hotstack.xlarge  --public --vcpus  8 --ram 16384 --disk 160
-openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 160
+openstack flavor create hotstack.xlarge  --public --vcpus  8 --ram 16384 --disk 200
+openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 200
 ```
 
 ### Cloud secret

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -63,8 +63,8 @@ openstack flavor create hotstack.small   --public --vcpus  1 --ram  2048 --disk 
 openstack flavor create hotstack.medium  --public --vcpus  2 --ram  4096 --disk  40
 openstack flavor create hotstack.large   --public --vcpus  4 --ram  8192 --disk  80
 openstack flavor create hotstack.xlarge  --public --vcpus  8 --ram 16384 --disk 160
-openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 160
-openstack flavor create hotstack.xxxlarge --public --vcpus 12 --ram 49152 --disk 160
+openstack flavor create hotstack.xxlarge --public --vcpus 12 --ram 32768 --disk 200
+openstack flavor create hotstack.xxxlarge --public --vcpus 12 --ram 49152 --disk 200
 ```
 
 ### Project


### PR DESCRIPTION
Ran out of diskspace during provisioning of baremetal hosts when testing with downstream content.