### PR TITLE
Load automation vars directly to hotloop var name

### DIFF
--- a/05_deploy_rhoso.yml
+++ b/05_deploy_rhoso.yml
@@ -31,14 +31,13 @@
       ansible.builtin.include_vars:
         file: dataplane_ssh_keys_vars.yaml
 
-    - name: Load automation vars
+    - name: "Load automation vars - store in variable: automation"
       ansible.builtin.include_vars:
         file: "{{ automation_vars_file }}"
-        name: automation_vars
+        name: automation
 
   roles:
     - role: hotloop
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"
-        automation: "{{ automation_vars }}"

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -219,7 +219,7 @@ stages:
       ansible.builtin.include_vars:
         file: dataplane_ssh_keys_vars.yaml
 
-    - name: Load automation vars
+    - name: "Load automation vars and store in variable: automation"
       ansible.builtin.include_vars:
         file: "{{ automation_vars_file }}"
         name: automation
@@ -229,5 +229,4 @@ stages:
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"
-        automation: "{{ automation }}"
 ```


### PR DESCRIPTION
Instead of storing as `automation_vars` and passing, just load directly to `atomation` and drop setting the var for the role.