### PR TITLE
Support additionalTrustedCA

### DIFF
--- a/roles/ocp_agent_installer/defaults/main.yml
+++ b/roles/ocp_agent_installer/defaults/main.yml
@@ -65,3 +65,8 @@ enable_image_content_source_policy: false
 # To enable ImageContentSourcePolicy (ICSP), set this variable to contain the value
 # for the ICSP spec's repositoryDigestMirrors field.
 image_content_source_policy_mirrors: []
+
+enable_additional_trusted_ca: false
+ocp_additional_trusted_ca:
+  - name: registry-proxy.engineering.redhat.com
+    url: https://url.corp.redhat.com/hotstack-ca

--- a/roles/ocp_agent_installer/files/additional-trusted-ca-config-image.yaml
+++ b/roles/ocp_agent_installer/files/additional-trusted-ca-config-image.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+spec:
+  additionalTrustedCA:
+    name: hotstack-additional-trusted-ca

--- a/roles/ocp_agent_installer/tasks/additional_ca.yml
+++ b/roles/ocp_agent_installer/tasks/additional_ca.yml
@@ -1,0 +1,53 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert
+  ansible.builtin.assert:
+    that:
+      - ca.name is defined
+      - ca.name | length > 0
+      - ca.url is defined or ca.data is defined
+      - (
+          ca.url | length > 0 or
+          ca.data | length > 0
+        )
+
+- name: Download the CA bundle if url
+  when: ca.url is defined
+  ansible.builtin.uri:
+    url: "{{ ca.url }}"
+    method: get
+    return_content: true
+    validate_certs: false
+  register: __get_ca_from_url_result
+  ignore_errors: true
+
+- name: Append to _ocp_additional_trusted_ca_map
+  when: (
+          ca.data is defined or
+          (
+            ca.url is defined and
+            not __get_ca_from_url_result.failed
+          )
+        )
+  ansible.builtin.set_fact:
+    _ocp_additional_trusted_ca_map: >-
+      {{
+        _ocp_additional_trusted_ca_map |
+        combine(
+          {ca.name: ca.data | default(__get_ca_from_url_result.content)}
+        )
+      }}

--- a/roles/ocp_agent_installer/tasks/config_assets.yml
+++ b/roles/ocp_agent_installer/tasks/config_assets.yml
@@ -49,3 +49,41 @@
           '95-image-content-source-policy.yaml'
         ] | ansible.builtin.path_join
       }}
+
+- name: Additional trusted CA
+  when:
+    - enable_additional_trusted_ca | bool
+    - ocp_additional_trusted_ca is defined
+    - ocp_additional_trusted_ca | length > 0
+  block:
+    - name: Initialize _ocp_additional_trusted_ca_map fact
+      ansible.builtin.set_fact:
+        _ocp_additional_trusted_ca_map: {}
+
+    - name: Append to _ocp_additional_trusted_ca_map fact
+      ansible.builtin.include_tasks: additional_ca.yml
+      loop: "{{ ocp_additional_trusted_ca }}"
+      loop_control:
+        loop_var: ca
+
+    - name: Template additional CA config map
+      ansible.builtin.template:
+        src: additional-trusted-ca-config-map.yaml.j2
+        dest: >-
+          {{
+            [
+              config_assets_dir,
+              '93-additional-ca-config-map.yaml'
+            ] | ansible.builtin.path_join
+          }}
+
+    - name: Copy additional CA config image
+      ansible.builtin.copy:
+        src: additional-trusted-ca-config-image.yaml
+        dest: >-
+          {{
+            [
+              config_assets_dir,
+              '94-additional-ca-config-image.yaml'
+            ] | ansible.builtin.path_join
+          }}

--- a/roles/ocp_agent_installer/templates/additional-trusted-ca-config-map.yaml.j2
+++ b/roles/ocp_agent_installer/templates/additional-trusted-ca-config-map.yaml.j2
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-config
+  name: hotstack-additional-trusted-ca
+data:
+{% for ca in ocp_additional_trusted_ca %}
+  {{ ca.name }}: |
+    {{ _ocp_additional_trusted_ca_map[ca.name] | indent(width=4) }}
+{% endfor %}


### PR DESCRIPTION
The certificates will be added to a ConfigMap resource named `hotstack-additional-trusted-ca` in the `openshift-config` namespace. And the `images.config.openshift.io` `cluster` resrouce will be configured to reference this config map in the `additionalTrustedCA` field of the resource spec.

```yaml
enable_additional_trusted_ca: true
ocp_additional_trusted_ca:
  - name: reg-proxy.example.com
    url: https://url.corp.redhat.com/hotstack-ca
```