### PR TITLE
re-factor to use nested stages

### DIFF
--- a/roles/hotloop/files/common/manifests/metallb.yaml
+++ b/roles/hotloop/files/common/manifests/metallb.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/roles/hotloop/files/common/manifests/nmstate.yaml
+++ b/roles/hotloop/files/common/manifests/nmstate.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate

--- a/roles/hotloop/files/common/manifests/olm-deps.yaml
+++ b/roles/hotloop/files/common/manifests/olm-deps.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: cert-manager-operator
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: metallb-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: openshift-nmstate
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: >-
+      CertManager.v1alpha1.operator.openshift.io,
+      Certificate.v1.cert-manager.io,
+      CertificateRequest.v1.cert-manager.io,
+      Challenge.v1.acme.cert-manager.io,
+      ClusterIssuer.v1.cert-manager.io,
+      Issuer.v1.cert-manager.io,
+      Order.v1.acme.cert-manager.io
+  generateName: cert-manager-operator-
+  name: cert-manager-operator-bccwx
+  namespace: cert-manager-operator
+spec:
+  targetNamespaces:
+  - cert-manager-operator
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: NMState.v1.nmstate.io
+  generateName: openshift-nmstate-
+  name: openshift-nmstate-tn6k8
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator: ""
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator-sub
+  namespace: metallb-system
+spec:
+  channel: stable
+  name: metallb-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/observability-operator.openshift-operators: ""
+  name: observability-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/roles/hotloop/files/common/manifests/olm-openstack.yaml.j2
+++ b/roles/hotloop/files/common/manifests/olm-openstack.yaml.j2
@@ -1,0 +1,105 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: openstack
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: openstack-operators
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openstack
+  namespace: openstack-operators
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: openstack-operator-index
+  namespace: openstack-operators
+spec:
+  image: {{ openstack_operators_image }}
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-operator
+  namespace: openstack-operators
+spec:
+  channel: {{ openstack_operator_channel }}
+  name: openstack-operator
+  source: openstack-operator-index
+  sourceNamespace: openstack-operators
+  installPlanApproval: Manual
+{% if openstack_operators_starting_csv | default(none) %}
+  startingCSV: openstack-operator.{{ openstack_operators_starting_csv }}
+{% endif %}
+
+{%- if openstack_operators_starting_csv | default(none) and
+        openstack_operator_channel != 'alpha' -%}
+{%     if openstack_operators_starting_csv is version('v1.0.4', '<') %}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-ansibleee
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: {{ openstack_operator_channel }}
+  installPlanApproval: Manual
+  name: openstack-ansibleee-operator
+  source: openstack-operator-index
+  sourceNamespace: openstack-operators
+  startingCSV: openstack-ansibleee-operator.{{ openstack_operators_starting_csv }}
+{%     endif %}
+{%     for operator_name in [
+            'barbican',
+            'cinder',
+            'designate',
+            'glance',
+            'heat',
+            'infra',
+            'ironic',
+            'keystone',
+            'manila',
+            'mariadb',
+            'neutron',
+            'nova',
+            'octavia',
+            'openstack-baremetal',
+            'ovn',
+            'placement',
+            'rabbitmq-cluster',
+            'swift',
+            'telemetry'
+          ]
+          if openstack_operators_starting_csv is version('v1.0.7', '<') %}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ operator_name }}
+  namespace: openstack-operators
+  labels:
+    category: openstack-subscription
+spec:
+  channel: {{ openstack_operator_channel }}
+  installPlanApproval: Manual
+  name: {{ operator_name }}-operator
+  source: openstack-operator-index
+  sourceNamespace: openstack-operators
+  startingCSV: {{ operator_name }}-operator.{{ openstack_operators_starting_csv }}
+{%     endfor %}
+{%- endif -%}

--- a/roles/hotloop/files/common/manifests/openstack.yaml
+++ b/roles/hotloop/files/common/manifests/openstack.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: operator.openstack.org/v1beta1
+kind: OpenStack
+metadata:
+  name: openstack
+  namespace: openstack-operators

--- a/roles/hotloop/files/common/manifests/topolvm.yaml
+++ b/roles/hotloop/files/common/manifests/topolvm.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: openshift-storage
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+  - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms
+  namespace: openshift-storage
+spec:
+  installPlanApproval: Automatic
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/roles/hotloop/files/common/manifests/topolvmcluster.yaml
+++ b/roles/hotloop/files/common/manifests/topolvmcluster.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvmcluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+    - name: local-storage
+      fstype: xfs
+      default: true
+      deviceSelector:
+        paths:
+        - /dev/vdb
+        forceWipeDevicesAndDestroyAllData: true
+      thinPoolConfig:
+        name: topolvms_thin_pool
+        sizePercent: 90
+        overprovisionRatio: 10

--- a/roles/hotloop/files/common/scripts/approve_install_plan.sh
+++ b/roles/hotloop/files/common/scripts/approve_install_plan.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+NAMESPACE=openstack-operators
+SUBSCRIPTIONS=subscriptions.operators.coreos.com
+INSTALL_PLANS=installplans.operators.coreos.com
+PATCH=(-p '{"spec":{"approved":true}}' --type merge)
+NAME=openstack-operator
+
+INSTALLED_CSV=$(oc -n ${NAMESPACE} get ${SUBSCRIPTIONS} ${NAME} \
+                -o jsonpath='{ .status.installedCSV }')
+
+if [ -z "$INSTALLED_CSV" ]; then
+    INSTALL_PLAN=$(oc -n ${NAMESPACE} get ${SUBSCRIPTIONS} ${NAME} \
+                   -o jsonpath='{ .status.installPlanRef.name }')
+
+    oc -n ${NAMESPACE} patch ${INSTALL_PLANS} "${INSTALL_PLAN}" "${PATCH[@]}"
+fi

--- a/roles/hotloop/files/common/scripts/leader_election_tune.sh
+++ b/roles/hotloop/files/common/scripts/leader_election_tune.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -x
+
+CSV_NAME=$(oc -n openstack-operators get csv \
+            -l operators.coreos.com/openstack-operator.openstack-operators= -o json \
+            | jq -r '.items[0].metadata.name')
+
+DEPLOYMENT_INDEX=$(oc -n openstack-operators get csv "${CSV_NAME}" -o json | \
+  jq '.spec.install.spec.deployments[].name |
+      index("openstack-operator-controller-operator") | select( . != null )')
+
+# Older versions don't have these env vars, just exit without error
+if [ -z "$DEPLOYMENT_INDEX" ]; then
+  exit 0
+fi
+
+CONTAINER_INDEX=$(oc -n openstack-operators get csv "${CSV_NAME}" -o json | \
+  jq --arg DEPLOYMENT_INDEX "${DEPLOYMENT_INDEX}"\
+    '.spec.install.spec.deployments[$DEPLOYMENT_INDEX | tonumber]
+     .spec.template.spec.containers[].name | index("operator") | select( . != null )')
+LEASE_DURATION_INDEX=$(oc -n openstack-operators get csv "${CSV_NAME}" -o json | \
+  jq '.spec.install.spec.deployments[] |
+      select(.name == "openstack-operator-controller-operator") |
+      .spec.template.spec.containers[] |
+      select(.name == "operator") | .env | map(.name == "LEASE_DURATION") |
+      index(true)')
+# Older versions don't have these env vars, just exit without error
+if [ "$LEASE_DURATION_INDEX" == "null" ]; then
+  exit 0
+fi
+
+RENEW_DEADLINE_INDEX=$(oc -n openstack-operators get csv "${CSV_NAME}" -o json | \
+  jq '.spec.install.spec.deployments[] |
+      select(.name == "openstack-operator-controller-operator") |
+      .spec.template.spec.containers[] |
+      select(.name == "operator") | .env | map(.name == "RENEW_DEADLINE") |
+      index(true)')
+RETRY_PERIOD_INDEX=$(oc -n openstack-operators get csv "${CSV_NAME}" -o json | \
+  jq '.spec.install.spec.deployments[] |
+      select(.name == "openstack-operator-controller-operator") |
+      .spec.template.spec.containers[] |
+      select(.name == "operator") | .env | map(.name == "RETRY_PERIOD") |
+      index(true)')
+
+
+oc -n openstack-operators patch csv "${CSV_NAME}" --type=json \
+  -p="[
+        {'op': 'replace',
+        'path': '/spec/install/spec/deployments/$DEPLOYMENT_INDEX/spec/template/spec/containers/$CONTAINER_INDEX/env/$LEASE_DURATION_INDEX/value',
+        'value': '50'},
+        {'op': 'replace',
+        'path': '/spec/install/spec/deployments/$DEPLOYMENT_INDEX/spec/template/spec/containers/$CONTAINER_INDEX/env/$RENEW_DEADLINE_INDEX/value',
+        'value': '30'},
+        {'op': 'replace',
+        'path': '/spec/install/spec/deployments/$DEPLOYMENT_INDEX/spec/template/spec/containers/$CONTAINER_INDEX/env/$RETRY_PERIOD_INDEX/value',
+        'value': '10'}
+      ]"

--- a/roles/hotloop/files/common/stages/cinder-lvm-label-stages.yaml
+++ b/roles/hotloop/files/common/stages/cinder-lvm-label-stages.yaml
@@ -1,0 +1,14 @@
+---
+- name: Node label cinder-lvm
+  documentation: |
+    The LVM backend for Cinder is a special case as the storage data is on
+    the OpenShift node and has no external storage systems. This has several
+    implications.
+
+    * To prevent issues with exported volumes, cinder-operator automatically
+      uses the host network. The backend is configured to use the host's
+      VLAN IP address. This means that the cinder-volume service doesn't
+      need any networkAttachments.
+    * There can only be one node with the label openstack.org/cinder-lvm=.
+      Apply the label using the command: ``oc label node <nodename> openstack.org/cinder-lvm=``
+  cmd: "oc label node master-0 openstack.org/cinder-lvm="

--- a/roles/hotloop/templates/common/scripts/brew_edpm_bootstrap_command.sh.j2
+++ b/roles/hotloop/templates/common/scripts/brew_edpm_bootstrap_command.sh.j2
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+mkdir -p /root/.config/containers/
+
+cat << EOF > /root/.config/containers/policy.json
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ]
+}
+EOF
+
+# root CA
+pushd /etc/pki/ca-trust/source/anchors/
+curl -Lk -o hotstack-ca.pem {{ hotstack_install_ca_url }}
+update-ca-trust
+popd
+
+# install rhos-release repos
+curl -Lk -o rhos-release.rpm {{ hotstack_rhos_release_rpm }}
+dnf --nogpgcheck install -y rhos-release.rpm
+rhos-release {{ hotstack_rhos_release_args }}

--- a/roles/hotloop/templates/common/scripts/upstream_edpm_bootstrap_command.sh.j2
+++ b/roles/hotloop/templates/common/scripts/upstream_edpm_bootstrap_command.sh.j2
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -euxo pipefail
+
+pushd /var/tmp
+
+curl -sL https://github.com/openstack-k8s-operators/repo-setup/archive/refs/heads/main.tar.gz | tar -xz
+
+pushd repo-setup-main
+
+python3 -m venv ./venv
+PBR_VERSION=0.0.0 ./venv/bin/pip install ./
+
+# This is required for FIPS enabled until trunk.rdoproject.org
+# is not being served from a centos7 host, tracked by
+# https://issues.redhat.com/browse/RHOSZUUL-1517
+update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+
+./venv/bin/repo-setup current-podified -b antelope
+
+popd
+
+rm -rf repo-setup-main

--- a/roles/hotloop/templates/common/stages/metal-platofrm-provisioning.yaml.j2
+++ b/roles/hotloop/templates/common/stages/metal-platofrm-provisioning.yaml.j2
@@ -1,0 +1,8 @@
+---
+- name: Metal platform Provisioning CR
+  documentation: |
+    Create a Provisioning custom resource (CR) to enable OCP Metal platform components
+  manifest: "{{ role_path }}/files/common/provisioning.yaml"
+  wait_conditions:
+    - "sleep 30"
+    - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=300s"

--- a/roles/hotloop/templates/common/stages/olm-deps-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-deps-stages.yaml.j2
@@ -1,0 +1,29 @@
+---
+- name: Common OLM Dependencis
+  documentation: |
+    Install the OpenStack K8S dependencies. (Namespaces, OperatorGroup, and Subscription CRs.)
+
+    Once these CRs are created, run the `oc wait` commands to confirm that
+    each step of this procedure is complete.
+  manifest: "{{ role_path }}/files/common/manifests/olm-deps.yaml"
+  wait_conditions:
+    - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
+    - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
+    - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
+    - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
+    - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
+    - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+
+- name: Common MetalLB
+  manifest: "{{ role_path }}/files/common/manifests/metallb.yaml"
+  wait_conditions:
+    - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+
+- name: Common NMState
+  manifest: "{{ role_path }}/files/common/manifests/nmstate.yaml"
+  wait_conditions:
+    - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
+    - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"

--- a/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
@@ -1,0 +1,54 @@
+---
+- name: Common Openstack OLM
+  documentation: |
+    Install the OpenStack K8S operators (Namespaces, OperatorGroup, and Subscription CRs.)
+
+    Once these CRs are created, run the `oc wait` commands to confirm that
+    each step of this procedure is complete.
+  j2_manifest: "{{ role_path }}/files/common/manifests/olm-openstack.yaml.j2"
+  wait_conditions:
+    - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - >-
+      oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
+      --for jsonpath='{.status.state}' --timeout=300s
+
+- name: Approve openstack-operator Install plan
+  script: |
+    {{
+      lookup('ansible.builtin.file',
+              'common/scripts/approve_install_plan.sh')
+      | indent(width=4)
+    }}
+  wait_conditions:
+    - >-
+      oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
+- name: Patch openstack leader election tuneables
+  script: |
+    {{
+      lookup('ansible.builtin.file',
+              'common/scripts/leader_election_tune.sh')
+      | indent(width=4)
+    }}
+
+- name: Openstack
+  manifest: "{{ role_path }}/files/common/manifests/openstack.yaml"
+  wait_conditions:
+    - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
+    - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
+    - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
+    - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
+    - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
+    - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
+    - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
+    - "sleep 30"  # The {.status.loadBalancer} wait conditions are not working?
+  run_conditions:
+    - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
+      condition: >-
+        {{
+          openstack_operator_channel == 'alpha' or
+          openstack_operators_starting_csv | default(none) is none or
+          openstack_operators_starting_csv is version('v1.0.6', '>')
+        }}

--- a/roles/hotloop/templates/common/stages/topolvm-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/topolvm-stages.yaml.j2
@@ -1,0 +1,35 @@
+---
+- name: TopoLVM common
+  documentation: |
+    Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
+    cluster.
+
+    It uses LVMS (Logical Volume Manager Storage) to dynamically provision
+    local storage built from block devices on OCP nodes.
+
+    After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
+  manifest: "{{ role_path }}/files/common/manifests/topolvm.yaml"
+  wait_conditions:
+    - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - >-
+      oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
+      --for jsonpath='{.status.namespaces}' --timeout=30s
+    - >-
+      oc wait -n openshift-storage ClusterServiceVersion
+      -l operators.coreos.com/lvms-operator.openshift-storage
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+
+- name: TopoLVM LVMCluster
+  documentation: |
+    Create a TopoLVM - LVMCluster on the Openshift cluster.
+
+    Configure the LVMCluster custom resource (CR) to perform the following
+    actions:
+
+    * Create LVM volume groups that you can use to provision persistent
+      volume claims (PVCs).
+    * Configure a list of devices that you want to add to the LVM volume
+      groups.
+  manifest: "{{ role_path }}/files/common/manifests/topolvmcluster.yaml"
+  wait_conditions:
+    - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -1,98 +1,32 @@
 ---
 stages:
-  - name: TopoLVM common
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    documentation: |
-      Create a TopoLVM - LVMCluster on the Openshift cluster.
-
-      Configure the LVMCluster custom resource (CR) to perform the following
-      actions:
-
-      * Create LVM volume groups that you can use to provision persistent
-        volume claims (PVCs).
-      * Configure a list of devices that you want to add to the LVM volume
-        groups.
-    manifest: ../common/topolvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Node label cinder-lvm
-    cmd: "oc label node master-0 openstack.org/cinder-lvm="
-
-  - name: Common OLM
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+  - name: Cinder LVM
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
       }}
 
-  - name: Common MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: TopoLVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
+      }}
 
-  - name: Common NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: NodeNetworkConfigurationPolicy (nncp)
     manifest: manifests/control-plane/networking/nncp.yaml

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -1,92 +1,25 @@
 ---
 stages:
-  - name: TopoLVM common
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    manifest: manifests/topolvm/lvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Common OLM
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+  - name: TopoLVM
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
       }}
 
-  - name: Common MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Common NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
-
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-      - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-      - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: NodeNetworkConfigurationPolicy (nncp)
     manifest: manifests/control-plane/nncp/nncp.yaml

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -1,139 +1,41 @@
 ---
 stages:
-  - name: TopoLVM common
-    documentation: |
-      Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
-      cluster.
+  - name: Cinder LVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
+      }}
 
-      It uses LVMS (Logical Volume Manager Storage) to dynamically provision
-      local storage built from block devices on OCP nodes.
-
-      After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    documentation: |
-      Create a TopoLVM - LVMCluster on the Openshift cluster.
-
-      Configure the LVMCluster custom resource (CR) to perform the following
-      actions:
-
-      * Create LVM volume groups that you can use to provision persistent
-        volume claims (PVCs).
-      * Configure a list of devices that you want to add to the LVM volume
-        groups.
-    manifest: ../common/topolvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Node label cinder-lvm
-    documentation: |
-      The LVM backend for Cinder is a special case as the storage data is on
-      the OpenShift node and has no external storage systems. This has several
-      implications.
-
-      * To prevent issues with exported volumes, cinder-operator automatically
-        uses the host network. The backend is configured to use the host's
-        VLAN IP address. This means that the cinder-volume service doesn't
-        need any networkAttachments.
-      * There can only be one node with the label openstack.org/cinder-lvm=.
-        Apply the label using the command: ``oc label node <nodename> openstack.org/cinder-lvm=``
-    cmd: "oc label node master-0 openstack.org/cinder-lvm="
+  - name: TopoLVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
+      }}
 
   - name: Metal platform Provisioning CR
     documentation: |
       Create a Provisioning custom resource (CR) to enable OCP Metal platform components
-    manifest: ../common/provisioning.yaml
-    wait_conditions:
-      - "sleep 30"
-      - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=300s"
-
-  - name: Common OLM
-    documentation: |
-      Install the OpenStack K8S operators and their dependencies. (Namespaces,
-      OperatorGroup, and Subscription CRs.)
-
-      Once these CRs are created, run the `oc wait` commands to confirm that
-      each step of this procedure is complete.
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.template",
+               "common/stages/metal-platofrm-provisioning.yaml.j2")
       }}
 
-  - name: Common MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Common NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
-
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-      - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-      - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "sleep 120"  # The {.status.loadBalancer} wait conditions are not working?
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: Namespaces
     manifest: ./manifests/namespaces.yaml

--- a/scenarios/sno-2-bm/automation-vars.yml
+++ b/scenarios/sno-2-bm/automation-vars.yml
@@ -1,130 +1,32 @@
 ---
 stages:
-  - name: TopoLVM common
-    documentation: |
-      Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
-      cluster.
-
-      It uses LVMS (Logical Volume Manager Storage) to dynamically provision
-      local storage built from block devices on OCP nodes.
-
-      After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    documentation: |
-      Create a TopoLVM - LVMCluster on the Openshift cluster.
-
-      Configure the LVMCluster custom resource (CR) to perform the following
-      actions:
-
-      * Create LVM volume groups that you can use to provision persistent
-        volume claims (PVCs).
-      * Configure a list of devices that you want to add to the LVM volume
-        groups.
-    manifest: ../common/topolvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Node label cinder-lvm
-    documentation: |
-      The LVM backend for Cinder is a special case as the storage data is on
-      the OpenShift node and has no external storage systems. This has several
-      implications.
-
-      * To prevent issues with exported volumes, cinder-operator automatically
-        uses the host network. The backend is configured to use the host's
-        VLAN IP address. This means that the cinder-volume service doesn't
-        need any networkAttachments.
-      * There can only be one node with the label openstack.org/cinder-lvm=.
-        Apply the label using the command: ``oc label node <nodename> openstack.org/cinder-lvm=``
-    cmd: "oc label node master-0 openstack.org/cinder-lvm="
-
-  - name: Common OLM
-    documentation: |
-      Install the OpenStack K8S operators and their dependencies. (Namespaces,
-      OperatorGroup, and Subscription CRs.)
-
-      Once these CRs are created, run the `oc wait` commands to confirm that
-      each step of this procedure is complete.
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+  - name: Cinder LVM
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
       }}
 
-  - name: Common MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: TopoLVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
+      }}
 
-  - name: Common NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-      - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-      - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "sleep 30"  # The {.status.loadBalancer} wait conditions are not working?
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: NodeNetworkConfigurationPolicy (nncp)
     manifest: manifests/control-plane/networking/nncp.yaml

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -1,139 +1,41 @@
 ---
 stages:
-  - name: TopoLVM common
-    documentation: |
-      Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
-      cluster.
+  - name: Cinder LVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
+      }}
 
-      It uses LVMS (Logical Volume Manager Storage) to dynamically provision
-      local storage built from block devices on OCP nodes.
-
-      After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    documentation: |
-      Create a TopoLVM - LVMCluster on the Openshift cluster.
-
-      Configure the LVMCluster custom resource (CR) to perform the following
-      actions:
-
-      * Create LVM volume groups that you can use to provision persistent
-        volume claims (PVCs).
-      * Configure a list of devices that you want to add to the LVM volume
-        groups.
-    manifest: ../common/topolvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Node label cinder-lvm
-    documentation: |
-      The LVM backend for Cinder is a special case as the storage data is on
-      the OpenShift node and has no external storage systems. This has several
-      implications.
-
-      * To prevent issues with exported volumes, cinder-operator automatically
-        uses the host network. The backend is configured to use the host's
-        VLAN IP address. This means that the cinder-volume service doesn't
-        need any networkAttachments.
-      * There can only be one node with the label openstack.org/cinder-lvm=.
-        Apply the label using the command: ``oc label node <nodename> openstack.org/cinder-lvm=``
-    cmd: "oc label node master-0 openstack.org/cinder-lvm="
+  - name: TopoLVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
+      }}
 
   - name: Metal platform Provisioning CR
     documentation: |
       Create a Provisioning custom resource (CR) to enable OCP Metal platform components
-    manifest: ../common/provisioning.yaml
-    wait_conditions:
-      - "sleep 30"
-      - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=300s"
-
-  - name: Common OLM
-    documentation: |
-      Install the OpenStack K8S operators and their dependencies. (Namespaces,
-      OperatorGroup, and Subscription CRs.)
-
-      Once these CRs are created, run the `oc wait` commands to confirm that
-      each step of this procedure is complete.
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.template",
+               "common/stages/metal-platofrm-provisioning.yaml.j2")
       }}
 
-  - name: Common MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Common NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
-
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-      - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-      - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "sleep 30"  # The {.status.loadBalancer} wait conditions are not working?
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: NodeNetworkConfigurationPolicy (nncp)
     manifest: manifests/control-plane/networking/nncp.yaml

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -1,131 +1,32 @@
 ---
 stages:
-  - name: TopoLVM CSI driver
-    documentation: |
-      Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
-      cluster.
-
-      It uses LVMS (Logical Volume Manager Storage) to dynamically provision
-      local storage built from block devices on OCP nodes.
-
-      After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
-    manifest: ../common/topolvm.yaml
-    wait_conditions:
-      - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - >-
-        oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
-        --for jsonpath='{.status.namespaces}' --timeout=30s
-      - >-
-        oc wait -n openshift-storage ClusterServiceVersion
-        -l operators.coreos.com/lvms-operator.openshift-storage
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-  - name: TopoLVM LVMCluster
-    documentation: |
-      Create a TopoLVM - LVMCluster on the Openshift cluster.
-
-      Configure the LVMCluster custom resource (CR) to perform the following
-      actions:
-
-      * Create LVM volume groups that you can use to provision persistent
-        volume claims (PVCs).
-      * Configure a list of devices that you want to add to the LVM volume
-        groups.
-    manifest: ../common/topolvmcluster.yaml
-    wait_conditions:
-      - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
-
-  - name: Node label cinder-lvm
-    documentation: |
-      The LVM backend for Cinder is a special case as the storage data is on
-      the OpenShift node and has no external storage systems. This has several
-      implications.
-
-      * To prevent issues with exported volumes, cinder-operator automatically
-        uses the host network. The backend is configured to use the host's
-        VLAN IP address. This means that the cinder-volume service doesn't
-        need any networkAttachments.
-      * There can only be one node with the label openstack.org/cinder-lvm=.
-        Apply the label using the command: ``oc label node <nodename> openstack.org/cinder-lvm=``
-    cmd: "oc label node master-0 openstack.org/cinder-lvm="
-
-  - name: OLM
-    documentation: |
-      Install the OpenStack K8S operators and their dependencies. (Namespaces,
-      OperatorGroup, and Subscription CRs.)
-
-      Once these CRs are created, run the `oc wait` commands to confirm that
-      each step of this procedure is complete.
-    j2_manifest: ../common/olm.yaml.j2
-    wait_conditions:
-      - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
-      - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-      - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-      - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
-      - >-
-        oc -n metallb-system wait service -l operators.coreos.com/metallb-operator.metallb-system=
-        --for jsonpath='{.status.loadBalancer}' --timeout=300s
-      - "oc wait -n openshift-nmstate deployments/nmstate-operator --for condition=Available --timeout=300s"
-      - >-
-        oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-        --for jsonpath='{.status.state}' --timeout=300s
-
-  - name: Approve openstack-operator Install plan
-    script: >-
+  - name: Cinder LVM
+    stages: >-
       {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/approve_install_plan.sh')
-      }}
-    wait_conditions:
-      - >-
-        oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-        --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
-
-
-  - name: Patch openstack leader election tuneables
-    script: >-
-      {{
-        lookup('ansible.builtin.file',
-               '{{ scenario_dir }}/common/scripts/leader_election_tune.sh')
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
       }}
 
-  - name: MetalLB
-    manifest: ../common/metallb.yaml
-    wait_conditions:
-      - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+  - name: TopoLVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-stages.yaml.j2")
+      }}
 
-  - name: NMState
-    manifest: ../common/nmstate.yaml
-    wait_conditions:
-      - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-      - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
+  - name: OLM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-deps-stages.yaml.j2")
+      }}
 
-  - name: Openstack
-    manifest: ../common/openstack.yaml
-    wait_conditions:
-      - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-      - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-      - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-      - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-      - "sleep 30"  # The {.status.loadBalancer} wait conditions are not working?
-    run_conditions:
-      - name: Always for `alpha` channel and greater than v1.0.6 for other channels.
-        condition: >-
-          {{
-            openstack_operator_channel == 'alpha' or
-            openstack_operators_starting_csv | default(none) is none or
-            openstack_operators_starting_csv is version('v1.0.6', '>')
-          }}
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
 
   - name: NodeNetworkConfigurationPolicy (nncp)
     manifest: manifests/control-plane/nncp/nncp.yaml


### PR DESCRIPTION
Add common stages, manifests and scripts in the hotloop role's `files` and `templates` directory.

Load the common stages using `lookup()` module in automation-vars for each scenario.