### PR TITLE
nodeset default patches

### DIFF
--- a/roles/hotloop/defaults/main.yml
+++ b/roles/hotloop/defaults/main.yml
@@ -31,3 +31,23 @@ hotstack_rhos_release_args: >-
 hotstack_edpm_bootstrap_command: "common/scripts/upstream_edpm_bootstrap_command.sh.j2"
 hotstack_install_ca_url: https://url.corp.redhat.com/hotstack-ca
 hotstack_rhos_release_rpm: https://url.corp.redhat.com/hotstack-rhos-release-latest-noarch-rpm
+
+# For convinience, a default patches for nodesets
+# * Sets edpm_bootstrap_command
+# * Set registries/registry logins if not already set in the nodeset YAML.
+hotstack_default_nodeset_patches:
+  - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
+    value: >-
+      {{
+        lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
+      }}
+  - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+    value: "{{ edpm_podman_registries }}"
+    where:
+      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+        value: null
+  - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
+    value: "{{ edpm_container_registry_logins }}"
+    where:
+      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
+        value: null

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -86,22 +86,7 @@ stages:
 
   - name: EDPM nodeset
     manifest: manifests/edpm/edpm.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
     wait_conditions:
       - >-
         oc -n openstack wait openstackdataplanenodeset openstack-edpm

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -64,22 +64,7 @@ stages:
 
   - name: EDPM nodeset (pre-ceph)
     manifest: manifests/edpm-pre-ceph/nodeset/nodeset.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
     wait_conditions:
       - >-
         oc -n openstack wait openstackdataplanenodeset openstack-edpm

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -183,22 +183,7 @@ stages:
 
   - name: Dataplane nodeset
     manifest: manifests/dataplanes/nodesets.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
     wait_conditions:
       - >-
         oc wait -n openstack-a openstackdataplanenodesets.dataplane.openstack.org

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -134,22 +134,7 @@ stages:
 
   - name: Dataplane nodeset
     manifest: manifests/dataplane/nodeset.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
     wait_conditions:
       - >-
         oc wait -n openstack openstackdataplanenodesets.dataplane.openstack.org

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -71,41 +71,11 @@ stages:
 
   - name: Networker nodeset
     manifest: manifests/networker/nodeset/nodeset.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
 
   - name: EDPM nodeset
     manifest: manifests/edpm/edpm.yaml
-    patches:
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_bootstrap_command
-        value: >-
-          {{
-            lookup('ansible.builtin.template', hotstack_edpm_bootstrap_command)
-          }}
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-        value: "{{ edpm_podman_registries }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
-      - path: spec.nodeTemplate.ansible.ansibleVars.edpm_container_registry_logins
-        value: "{{ edpm_container_registry_logins }}"
-        where:
-          - path: spec.nodeTemplate.ansible.ansibleVars.edpm_podman_registries
-            value: null
+    patches: "{{ hotstack_default_nodeset_patches }}"
 
   - name: Wait for nodesets (Networker and EDPM)
     wait_conditions:


### PR DESCRIPTION
Instead of repeating the same patched for nodeset in every scenario. Set the patches in a hotloop role default variable and re-use that accross scenarios.