### PR TITLE
Support update openstack-operator OLM

### DIFF
--- a/roles/hotloop/files/common/scripts/approve_update_install_plan.sh
+++ b/roles/hotloop/files/common/scripts/approve_update_install_plan.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+
+NAMESPACE=openstack-operators
+SUBSCRIPTIONS=subscriptions.operators.coreos.com
+INSTALL_PLANS=installplans.operators.coreos.com
+PATCH=(-p '{"spec": {"approved": true}}' --type merge)
+NAME=openstack-operator
+
+SUBSCRIPTION_STATE=$(oc -n ${NAMESPACE} get ${SUBSCRIPTIONS} ${NAME} \
+                     -o jsonpath='{ .status.state }')
+
+if [ "$SUBSCRIPTION_STATE" == "UpgradePending" ]; then
+    INSTALL_PLAN=$(oc -n ${NAMESPACE} get ${SUBSCRIPTIONS} ${NAME} \
+                   -o jsonpath='{ .status.installPlanRef.name }')
+
+    oc -n ${NAMESPACE} patch ${INSTALL_PLANS} "${INSTALL_PLAN}" "${PATCH[@]}"
+fi

--- a/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
@@ -17,7 +17,7 @@
   script: |
     {{
       lookup('ansible.builtin.file',
-              'common/scripts/approve_install_plan.sh')
+             'common/scripts/approve_install_plan.sh')
       | indent(width=4)
     }}
   wait_conditions:
@@ -29,7 +29,7 @@
   script: |
     {{
       lookup('ansible.builtin.file',
-              'common/scripts/leader_election_tune.sh')
+             'common/scripts/leader_election_tune.sh')
       | indent(width=4)
     }}
 

--- a/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
+++ b/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
@@ -1,0 +1,11 @@
+- name: Approve openstack-operator update Install plan
+  script: |
+    {{
+      lookup('ansible.builtin.file',
+             'common/scripts/approve_update_install_plan.sh')
+      | indent(width=4)
+    }}
+  wait_conditions:
+    - >-
+      oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -98,3 +98,16 @@ stages:
       - >-
         oc -n openstack wait openstackdataplanedeployment edpm-deployment
         --for condition=Ready --timeout=40m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -76,3 +76,16 @@ stages:
       - >-
         oc -n openstack wait openstackdataplanedeployment edpm-deployment-pre-ceph
         --for condition=Ready --timeout=40m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -137,3 +137,16 @@ stages:
       - >-
         oc wait -n openstack openstackdataplanedeployments.dataplane.openstack.org
         dataplane --for condition=Ready --timeout=40m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -201,3 +201,16 @@ stages:
       - >-
         oc wait -n openstack-b openstackdataplanedeployments.dataplane.openstack.org
         dataplane --for condition=Ready --timeout=40m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/sno-2-bm/automation-vars.yml
+++ b/scenarios/sno-2-bm/automation-vars.yml
@@ -51,3 +51,16 @@ stages:
       - >-
         oc wait -n openstack openstackcontrolplane controlplane
         --for condition=Ready --timeout=60m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -146,3 +146,16 @@ stages:
       - >-
         oc wait -n openstack openstackdataplanedeployments.dataplane.openstack.org
         dataplane --for condition=Ready --timeout=40m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -131,3 +131,16 @@ stages:
         COUNTER=$[$COUNTER +1]
         sleep 10
       done
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}


### PR DESCRIPTION
Add support to update opentack-operator OLM.

If `openstack_operators_update` variable is boolean `true` run a script to approve the install plan if subscription is `UpgradePending`.