### PR TITLE
Bump the retry count ...

### DIFF
--- a/roles/hotloop/defaults/main.yml
+++ b/roles/hotloop/defaults/main.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 wait_condition_retry_delay: 5
-wait_condition_retries: 25
+wait_condition_retries: 50
 manifests_dir: /home/zuul/manifests
 automation:
   stages: []


### PR DESCRIPTION
The wait condition on `Stage: Metal platform Provisioning CR` is failing sometimes, the wait fails with no resource found for quite some time ...

oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready