### PR TITLE
Add hotstack-wait-for-bmh tool

### DIFF
--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 controller_ansible_host:
 ansible_inventory: {}
-ssh_key_dir: /home/zuul/.ssh
-data_dir: /home/zuul/data
-cloud_config_dir: "/home/zuul/.hotcloud"
+base_dir: /home/zuul
+bin_dir: "{{ base_dir }}/bin"
+ssh_key_dir: "{{ base_dir }}/.ssh"
+data_dir: "{{ base_dir }}/data"
+cloud_config_dir: "{{ base_dir }}/.hotcloud"
 hotstack_cloud_secrets:
   auth_url: http://cloud.example.com:5000
   application_credential_id: app_credential_id

--- a/roles/controller/files/bin/hotstack-wait-for-bmh
+++ b/roles/controller/files/bin/hotstack-wait-for-bmh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit
+fi
+
+function usage {
+    echo "Wait for a BaremetalHost resrource to reach one of the states:"
+    echo " - available"
+    echo " - provisioned"
+    echo " - provisioning"
+    echo
+    echo "This command is intended to be run with timeout, for example:"
+    echo "  $ timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh3"
+    echo
+    echo "options:"
+    echo "  --namespace  Namespace (Required)"
+    echo "  --bmh        BaremetalHost name (Required)"
+    echo
+}
+
+function wait_for_baremetal_host {
+    until
+        STATE=$(oc get -n "${NAMESPACE}" baremetalhosts.metal3.io "${BMH}" \
+                -o jsonpath='{.status.provisioning.state}' \
+                | grep -o -e 'available' -e 'provisioned' -e 'provisioning')
+    do
+        sleep 10
+    done
+    echo "BaremetalHost ${BMH} found, state: ${STATE}"
+}
+
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        "--namespace")
+            NAMESPACE="$2";
+            shift
+        ;;
+        "--bmh")
+            BMH="$2";
+            shift
+        ;;
+        *)
+            echo "Unknown parameter passed: $1";
+            usage
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+if [[ -z "$NAMESPACE" || -z "$BMH" ]]; then
+    echo "Not enought arguments"
+    usage
+    exit 1
+fi
+
+wait_for_baremetal_host

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -31,11 +31,27 @@
         sleep: 2
         timeout: 300
 
-    - name: Ensure data directory exists
+    - name: Ensure directories exists
       ansible.builtin.file:
-        path: "{{ data_dir }}"
+        path: "{{ item }}"
         state: directory
         mode: '0755'
+      loop:
+        - "{{ data_dir }}"
+        - "{{ bin_dir }}"
+
+    - name: Add bin utilities to the bin_dir
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: >-
+          {{
+            [
+              bin_dir, item | ansible.builtin.basename
+            ] | ansible.builtin.path_join
+          }}
+        mode: '0755'
+      loop:
+        - bin/hotstack-wait-for-bmh
 
     - name: Write ansible inventory to file on controller-0
       when:

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -110,15 +110,8 @@ stages:
   - name: BaremetalHosts CRs
     j2_manifest: manifests/dataplane/baremetal_hosts.yaml.j2
     wait_conditions:
-      - sleep 20
-      - >-
-        oc wait -n openstack baremetalhosts.metal3.io bmh0
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
-      - >-
-        oc wait -n openstack baremetalhosts.metal3.io bmh1
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh0"
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh1"
 
   - name: Dataplane nodeset
     manifest: manifests/dataplane/nodeset.yaml

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -171,15 +171,8 @@ stages:
   - name: BaremetalHosts CRs
     j2_manifest: manifests/dataplanes/baremetal_hosts.yaml.j2
     wait_conditions:
-      - sleep 20
-      - >-
-        oc wait -n openstack-a baremetalhosts.metal3.io bmh-a-0
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
-      - >-
-        oc wait -n openstack-b baremetalhosts.metal3.io bmh-b-0
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack-a --bmh bmh-a-0"
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack-b --bmh bmh-b-0"
 
   - name: Dataplane nodeset
     manifest: manifests/dataplanes/nodesets.yaml

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -118,19 +118,9 @@ stages:
   - name: BaremetalHosts CRs
     j2_manifest: manifests/dataplane/baremetal_hosts.yaml.j2
     wait_conditions:
-      - sleep 20
-      - >-
-        oc wait -n openstack baremetalhosts.metal3.io bmh0
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
-      - >-
-        oc wait -n openstack baremetalhosts.metal3.io bmh1
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
-      - >-
-        oc wait -n openstack baremetalhosts.metal3.io bmh2
-        --for jsonpath='{.status.provisioning.state}=available'
-        --timeout=300s
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh0"
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh1"
+      - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh2"
 
   - name: Dataplane nodeset
     manifest: manifests/dataplane/nodeset.yaml


### PR DESCRIPTION
A script intended to run under `timeout` - wait until a BaremetalHost is one of `available`, `provsioning` or `provisioned`. Using this instead of oc wait improves re-run - with oc wait it would fail waiting for bmh to be `available` when it was already provisioned in a previous run.