### PR TITLE
Update version handling to support upstream

### DIFF
--- a/docs/hotloop_lang.md
+++ b/docs/hotloop_lang.md
@@ -87,9 +87,9 @@ Here's a breakdown of the common attributes within a stage:
       - "{{ foo is defined }}"
       - >-
         {{
-          openstack_operator_channel == 'alpha' or
-          openstack_operators_starting_csv | default(none) is none or
-          openstack_operators_starting_csv is version('v1.0.6', '>')
+          openstack_operators_starting_csv is defined and
+          openstack_operators_starting_csv is version('v1.0.0', '>=') and
+          openstack_operators_starting_csv is version('v1.0.7', '<')
         }}
     ```
 * **`stages`**: (Optional) This parameter allows you to define nested stages.

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -70,8 +70,8 @@ Schema for a stage item is:
       - "{{ foo is defined }}"
       - >-
         {{
-          openstack_operator_channel == 'alpha' or
           openstack_operators_starting_csv | default(none) is none or
+          openstack_operators_starting_csv is version('v1.0.0', '<') or
           openstack_operators_starting_csv is version('v1.0.6', '>')
         }}
     ```

--- a/roles/hotloop/files/common/manifests/olm-openstack.yaml.j2
+++ b/roles/hotloop/files/common/manifests/olm-openstack.yaml.j2
@@ -46,24 +46,8 @@ spec:
 {% endif %}
 
 {%- if openstack_operators_starting_csv | default(none) and
-        openstack_operator_channel != 'alpha' -%}
-{%     if openstack_operators_starting_csv is version('v1.0.4', '<') %}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: openstack-ansibleee
-  namespace: openstack-operators
-  labels:
-    category: openstack-subscription
-spec:
-  channel: {{ openstack_operator_channel }}
-  installPlanApproval: Manual
-  name: openstack-ansibleee-operator
-  source: openstack-operator-index
-  sourceNamespace: openstack-operators
-  startingCSV: openstack-ansibleee-operator.{{ openstack_operators_starting_csv }}
-{%     endif %}
+       openstack_operators_starting_csv is version('v1.0.0', '>=') and
+       openstack_operators_starting_csv is version('v1.0.7', '<') -%}
 {%     for operator_name in [
             'barbican',
             'cinder',
@@ -84,8 +68,7 @@ spec:
             'rabbitmq-cluster',
             'swift',
             'telemetry'
-          ]
-          if openstack_operators_starting_csv is version('v1.0.7', '<') %}
+          ] %}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription

--- a/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
@@ -33,7 +33,7 @@
       | indent(width=4)
     }}
 
-- name: Openstack
+- name: Openstack operator initialization resource
   manifest: "{{ role_path }}/files/common/manifests/openstack.yaml"
   wait_conditions:
     - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
@@ -47,7 +47,7 @@
   run_conditions:
     - >-
       {{
-        openstack_operator_channel == 'alpha' or
         openstack_operators_starting_csv | default(none) is none or
+        openstack_operators_starting_csv is version('v1.0.0', '<') or
         openstack_operators_starting_csv is version('v1.0.6', '>')
       }}

--- a/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
+++ b/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
@@ -21,12 +21,9 @@
     - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
     - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
   run_conditions:
-    # If v1.0.7 or later was used initially, this resource will already exist.
     - >-
       {{
-        openstack_operator_channel == 'stable-v1.0' and
-        (
-          openstack_operators_starting_csv is defined and
-          openstack_operators_starting_csv is version('v1.0.7', '<')
-        )
+        openstack_operators_starting_csv is defined and
+        openstack_operators_starting_csv is version('v1.0.0', '>=') and
+        openstack_operators_starting_csv is version('v1.0.7', '<')
       }}

--- a/update-vars.yml
+++ b/update-vars.yml
@@ -4,5 +4,5 @@
 #
 openstack_operators_update: true
 openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-index-upgrade:latest
-openstack_operators_starting_csv: 0.2.0
+openstack_operators_starting_csv: v0.2.0
 openstack_operator_channel: stable-v1.0


### PR DESCRIPTION
Update version handling to support upstream
    
For upstream always use the Openstack init resource, no need to support pre-fr2.

Upstream uses: `v0.x.x`, Downstream uses: `v1.x.x`
    
Also drop the pre `v1.0.4` support ...
