### PR TITLE
wait conditon retries only on no matching resource

### DIFF
--- a/roles/hotloop/tasks/execute_stage.yml
+++ b/roles/hotloop/tasks/execute_stage.yml
@@ -42,6 +42,7 @@
   loop: "{{ item.wait_conditions }}"
   loop_control:
     loop_var: wait_cmd
-  until: _wait_result.rc == 0
+  until: (_wait_result.rc == 0 or
+          not _wait_result.stderr is match(".*no matching resources found.*"))
   retries: "{{ wait_condition_retries }}"
   delay: "{{ wait_condition_retry_delay }}"

--- a/roles/hotloop/templates/common/stages/metal-platform-provisioning.yaml.j2
+++ b/roles/hotloop/templates/common/stages/metal-platform-provisioning.yaml.j2
@@ -4,5 +4,4 @@
     Create a Provisioning custom resource (CR) to enable OCP Metal platform components
   manifest: "{{ role_path }}/files/common/manifests/provisioning.yaml"
   wait_conditions:
-    - "sleep 30"
-    - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=300s"
+    - "oc wait pods -n openshift-machine-api -l k8s-app=metal3 --for condition=Ready --timeout=600s"

--- a/roles/hotloop/templates/common/stages/olm-deps-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-deps-stages.yaml.j2
@@ -7,23 +7,23 @@
     each step of this procedure is complete.
   manifest: "{{ role_path }}/files/common/manifests/olm-deps.yaml"
   wait_conditions:
-    - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=300s"
-    - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=300s"
-    - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=300s"
-    - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=300s"
-    - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=300s"
-    - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=300s"
-    - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=300s"
-    - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=300s"
-    - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=300s"
+    - "oc wait namespaces cert-manager-operator --for jsonpath='{.status.phase}=Active' --timeout=30s"
+    - "oc wait namespaces metallb-system --for jsonpath='{.status.phase}=Active' --timeout=30s"
+    - "oc wait namespaces openshift-nmstate --for jsonpath='{.status.phase}=Active' --timeout=30s"
+    - "oc wait -n cert-manager-operator pod --for condition=Ready -l name=cert-manager-operator --timeout=180s"
+    - "oc wait -n cert-manager pod -l app=cainjector --for condition=Ready --timeout=180s"
+    - "oc wait -n cert-manager pod -l app=webhook --for condition=Ready --timeout=180s"
+    - "oc wait -n cert-manager pod -l app=cert-manager --for condition=Ready --timeout=180s"
+    - "oc wait -n metallb-system pod -l control-plane=controller-manager --for condition=Ready --timeout=180s"
+    - "oc wait -n metallb-system pod -l component=webhook-server --for condition=Ready --timeout=180s"
 
 - name: Common MetalLB
   manifest: "{{ role_path }}/files/common/manifests/metallb.yaml"
   wait_conditions:
-    - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=300s"
+    - "oc wait -n metallb-system pod -l component=speaker --for condition=Ready --timeout=180s"
 
 - name: Common NMState
   manifest: "{{ role_path }}/files/common/manifests/nmstate.yaml"
   wait_conditions:
-    - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=300s"
-    - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=300s"
+    - "oc wait -n openshift-nmstate pod -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=180s"
+    - "oc wait -n openshift-nmstate deployments/nmstate-webhook --for condition=Available --timeout=180s"

--- a/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/olm-openstack-stages.yaml.j2
@@ -7,11 +7,11 @@
     each step of this procedure is complete.
   j2_manifest: "{{ role_path }}/files/common/manifests/olm-openstack.yaml.j2"
   wait_conditions:
-    - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=300s"
-    - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait namespaces openstack-operators --for jsonpath='{.status.phase}=Active' --timeout=30s"
+    - "oc wait namespaces openstack --for jsonpath='{.status.phase}=Active' --timeout=30s"
     - >-
       oc -n openstack-operators wait subscriptions.operators.coreos.com openstack-operator
-      --for jsonpath='{.status.state}' --timeout=300s
+      --for jsonpath='{.status.state}' --timeout=180s
 
 - name: Approve openstack-operator Install plan
   script: |
@@ -23,7 +23,7 @@
   wait_conditions:
     - >-
       oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=180s
 
 - name: Patch openstack leader election tuneables
   script: |
@@ -36,14 +36,13 @@
 - name: Openstack operator initialization resource
   manifest: "{{ role_path }}/files/common/manifests/openstack.yaml"
   wait_conditions:
-    - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-    - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-    - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-    - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-    - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    - "sleep 30"  # The {.status.loadBalancer} wait conditions are not working?
+    - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=180s"
+    - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=180s"
+    - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=180s"
+    - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=180s"
+    - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
+    - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
+    - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
   run_conditions:
     - >-
       {{

--- a/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
+++ b/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
@@ -8,18 +8,18 @@
   wait_conditions:
     - >-
       oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=180s
 
 - name: Apply Openstack init resource if startingCSV v1.0.6 or earlier
   manifest: "{{ role_path }}/files/common/manifests/openstack.yaml"
   wait_conditions:
-    - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=300s"
-    - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=300s"
-    - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=300s"
-    - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=300s"
-    - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
-    - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=300s"
+    - "oc wait -n openstack-operators openstack openstack --for condition=Ready --timeout=180s"
+    - "oc wait -n openstack-operators pod --for condition=Ready -l openstack.org/operator-name=openstack-controller --timeout=180s"
+    - "oc wait -n openstack-operators -l openstack.org/operator-name deployment --for condition=Available --timeout=180s"
+    - "oc wait -n openstack-operators -l app.kubernetes.io/name=rabbitmq-cluster-operator deployment --for condition=Available --timeout=180s"
+    - "oc wait -n openstack-operators service infra-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
+    - "oc wait -n openstack-operators service openstack-baremetal-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
+    - "oc wait -n openstack-operators service openstack-operator-webhook-service --for jsonpath='{.status.loadBalancer}' --timeout=180s"
   run_conditions:
     - >-
       {{

--- a/roles/hotloop/templates/common/stages/topolvm-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/topolvm-stages.yaml.j2
@@ -10,14 +10,14 @@
     After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
   manifest: "{{ role_path }}/files/common/manifests/topolvm.yaml"
   wait_conditions:
-    - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=300s"
+    - "oc wait namespaces openshift-storage --for jsonpath='{.status.phase}=Active' --timeout=180s"
     - >-
       oc wait -n openshift-storage operatorgroups.operators.coreos.com openshift-storage-operatorgroup
       --for jsonpath='{.status.namespaces}' --timeout=30s
     - >-
       oc wait -n openshift-storage ClusterServiceVersion
       -l operators.coreos.com/lvms-operator.openshift-storage
-      --for jsonpath='{.status.phase}=Succeeded' --timeout=300s
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=180s
 
 - name: TopoLVM LVMCluster
   documentation: |
@@ -32,4 +32,4 @@
       groups.
   manifest: "{{ role_path }}/files/common/manifests/topolvmcluster.yaml"
   wait_conditions:
-    - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=300s"
+    - "oc wait -n openshift-storage lvmcluster.lvm.topolvm.io/lvmcluster --for jsonpath='{.status.state}=Ready' --timeout=180s"

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -20,7 +20,7 @@ stages:
     stages: >-
       {{
         lookup("ansible.builtin.template",
-               "common/stages/metal-platofrm-provisioning.yaml.j2")
+               "common/stages/metal-platform-provisioning.yaml.j2")
       }}
 
   - name: OLM Dependencies

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -20,7 +20,7 @@ stages:
     stages: >-
       {{
         lookup("ansible.builtin.template",
-               "common/stages/metal-platofrm-provisioning.yaml.j2")
+               "common/stages/metal-platform-provisioning.yaml.j2")
       }}
 
   - name: OLM Dependencies

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -20,7 +20,7 @@ stages:
     stages: >-
       {{
         lookup("ansible.builtin.template",
-               "common/stages/metal-platofrm-provisioning.yaml.j2")
+               "common/stages/metal-platform-provisioning.yaml.j2")
       }}
 
   - name: OLM Dependencies


### PR DESCRIPTION
Only retry wait conditions if the strerr contains the matces `.*no matching resources found.*`.

This will make actual wait timeouts fail immideatly, i.e quicker fail results on actual issues.

Also tune some timeouts in the common stages.

... and fix a typo.