### PR TITLE
scenario: 3-nodes - disable horizon service

### DIFF
--- a/scenarios/3-nodes/manifests/control-plane/control-plane.yaml
+++ b/scenarios/3-nodes/manifests/control-plane/control-plane.yaml
@@ -196,7 +196,7 @@ spec:
   horizon:
     apiOverride:
       route: {}
-    enabled: true
+    enabled: false
     template:
       preserveJobs: false
       replicas: 1


### PR DESCRIPTION
When testing upstream `v0.2.0` horizon pod end up in `CrashLoopBack`.