### PR TITLE
Do not set `online` for BareMetalHost

### DIFF
--- a/scenarios/multi-nodeset/manifests/dataplane/baremetal_hosts.yaml.j2
+++ b/scenarios/multi-nodeset/manifests/dataplane/baremetal_hosts.yaml.j2
@@ -18,7 +18,6 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[0].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda
 ---
@@ -41,6 +40,5 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[1].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda

--- a/scenarios/multi-ns/manifests/dataplanes/baremetal_hosts.yaml.j2
+++ b/scenarios/multi-ns/manifests/dataplanes/baremetal_hosts.yaml.j2
@@ -18,7 +18,6 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[0].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda
 ---
@@ -41,6 +40,5 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[1].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda

--- a/scenarios/sno-bmh-tests/manifests/dataplane/baremetal_hosts.yaml.j2
+++ b/scenarios/sno-bmh-tests/manifests/dataplane/baremetal_hosts.yaml.j2
@@ -18,7 +18,6 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[0].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda
 ---
@@ -42,7 +41,6 @@ spec:
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[1].ports[0].address }}
   preprovisioningNetworkDataName: bmh1-preprovision-network-data
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda
 ---
@@ -65,6 +63,5 @@ spec:
     credentialsName: bmc-secret
   bootMACAddress: {{ stack_outputs.ironic_nodes.nodes[2].ports[0].address }}
   bootMode: UEFI
-  online: false
   rootDeviceHints:
     deviceName: /dev/vda


### PR DESCRIPTION
The `false` value is applied on re-run, effectively powering the node off.