### PR TITLE
Exponential retry openstack-version-patch

### DIFF
--- a/roles/controller/files/bin/hotstack-openstack-version-patch
+++ b/roles/controller/files/bin/hotstack-openstack-version-patch
@@ -48,9 +48,27 @@ function get_versions {
 
     if [ "${AVAILABLE_VERSION}" == "${DEPLOYED_VERSION}" ]
     then
-        echo "Deployed and available versions are the same."
-        exit 0
+        echo "Deployed and available versions are the same. Retrying ..."
+        return 1
     fi
+}
+
+function exponential_retry {
+    local cmd="$1"
+    local delay=1
+    local max_delay=64
+    if [ -z ${cmd} ]
+    then
+        echo "exponential_retry must be passed the command or function to run."
+        exit 1
+    fi
+    until (( delay > ${max_delay} )) || "${cmd}"
+    do
+        sleep "${delay}"
+        delay="$(( 2*delay ))"
+    done
+
+    (( delay > ${max_delay} )) && return 1 || return 0
 }
 
 function apply_patch {
@@ -94,5 +112,11 @@ if [ ! -f "$FILE" ]; then
 fi
 
 
-get_versions
+
+if ! exponential_retry get_versions
+then
+    echo "Deployed and available versions are the same."
+    exit 1
+else
+
 apply_patch


### PR DESCRIPTION
It may take some time for the new `availableVersion` to appear, add exponential retry function to give some time.