### PR TITLE
Dataplene deployment wait on jobs.batch

### DIFF
--- a/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
+++ b/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
@@ -8,7 +8,7 @@
   wait_conditions:
     - >-
       oc wait -n openstack-operators csv -l operators.coreos.com/openstack-operator.openstack-operators=
-      --for jsonpath='{.status.phase}=Succeeded' --timeout=450s
+      --for jsonpath='{.status.phase}=Succeeded' --timeout=600s
 
 - name: Apply Openstack init resource if startingCSV v1.0.6 or earlier
   manifest: "{{ role_path }}/files/common/manifests/openstack.yaml"

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -89,18 +89,28 @@ stages:
     patches: "{{ hotstack_default_nodeset_patches }}"
     wait_conditions:
       - >-
-        oc -n openstack wait openstackdataplanenodeset openstack-edpm
+        oc -n openstack wait openstackdataplanenodeset edpm
         --for condition=SetupReady --timeout=10m
 
   - name: EDPM deployment
     manifest: manifests/dataplane.yaml
     wait_conditions:
-      - >-
-        oc -n openstack wait openstackdataplanedeployment edpm-deployment
-        --for condition=Ready --timeout=40m
-      - >-
-        timeout --foreground 15m hotstack-nova-discover-hosts
-        --namespace openstack --num-computes 1
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch run-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch telemetry-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack openstackdataplanedeployment dataplane --for condition=Ready --timeout=10m
+      - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 1
 
   - name: Update openstack-operators OLM
     stages: >-

--- a/scenarios/3-nodes/manifests/dataplane.yaml
+++ b/scenarios/3-nodes/manifests/dataplane.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-deployment
+  name: dataplane
   namespace: openstack
 spec:
   nodeSets:

--- a/scenarios/3-nodes/manifests/edpm/edpm.yaml
+++ b/scenarios/3-nodes/manifests/edpm/edpm.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm
+  name: edpm
   namespace: openstack
 spec:
   env:

--- a/scenarios/3-nodes/manifests/update/update-ovn.yaml
+++ b/scenarios/3-nodes/manifests/update/update-ovn.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - ovn

--- a/scenarios/3-nodes/manifests/update/update-reboot.yaml
+++ b/scenarios/3-nodes/manifests/update/update-reboot.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - reboot-os
   ansibleExtraVars:

--- a/scenarios/3-nodes/manifests/update/update-services.yaml
+++ b/scenarios/3-nodes/manifests/update/update-services.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - update
     - reboot-os

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -119,20 +119,42 @@ stages:
     wait_conditions:
       - >-
         oc wait -n openstack openstackdataplanenodesets.dataplane.openstack.org
-        openstack-edpm-a --for condition=SetupReady --timeout=40m
+        edpm-a --for condition=SetupReady --timeout=40m
       - >-
         oc wait -n openstack openstackdataplanenodesets.dataplane.openstack.org
-        openstack-edpm-b --for condition=SetupReady --timeout=40m
+        edpm-b --for condition=SetupReady --timeout=40m
 
   - name: Dataplane Deployment
     manifest: manifests/dataplane/deployment.yaml
     wait_conditions:
-      - >-
-        oc wait -n openstack openstackdataplanedeployments.dataplane.openstack.org
-        dataplane --for condition=Ready --timeout=40m
-      - >-
-        timeout --foreground 15m hotstack-nova-discover-hosts
-        --namespace openstack --num-computes 2
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm-a --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm-b --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm-a --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm-b --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-os-dataplane-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm-a --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm-b --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=2m
+      - oc wait -n openstack jobs.batch run-os-dataplane-edpm-a --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch run-os-dataplane-edpm-b --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm-a --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm-b --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm-a --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm-b --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-edpm-a --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-edpm-b --for condition=Complete --timeout=20m
+      - oc wait -n openstack openstackdataplanedeployment edpm-a --for condition=Ready --timeout=10m
+      - oc wait -n openstack openstackdataplanedeployment edpm-b --for condition=Ready --timeout=10m
+      - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 2
 
   - name: Update openstack-operators OLM
     stages: >-

--- a/scenarios/multi-nodeset/manifests/dataplane/deployment.yaml
+++ b/scenarios/multi-nodeset/manifests/dataplane/deployment.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-  - openstack-edpm-a
-  - openstack-edpm-b
+  - edpm-a
+  - edpm-b

--- a/scenarios/multi-nodeset/manifests/dataplane/nodeset.yaml
+++ b/scenarios/multi-nodeset/manifests/dataplane/nodeset.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm-a
+  name: edpm-a
   namespace: openstack
 spec:
   env:
@@ -106,7 +106,7 @@ spec:
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm-b
+  name: edpm-b
   namespace: openstack
 spec:
   env:

--- a/scenarios/multi-nodeset/manifests/update/update-ovn.yaml
+++ b/scenarios/multi-nodeset/manifests/update/update-ovn.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm-a
-    - openstack-edpm-b
+    - edpm-a
+    - edpm-b
   servicesOverride:
     - ovn

--- a/scenarios/multi-nodeset/manifests/update/update-reboot.yaml
+++ b/scenarios/multi-nodeset/manifests/update/update-reboot.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm-a
-    - openstack-edpm-b
+    - edpm-a
+    - edpm-b
   servicesOverride:
     - reboot-os
   ansibleExtraVars:

--- a/scenarios/multi-nodeset/manifests/update/update-services.yaml
+++ b/scenarios/multi-nodeset/manifests/update/update-services.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm-a
-    - openstack-edpm-b
+    - edpm-a
+    - edpm-b
   servicesOverride:
     - update
     - reboot-os

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -128,17 +128,26 @@ stages:
     wait_conditions:
       - >-
         oc wait -n openstack openstackdataplanenodesets.dataplane.openstack.org
-        openstack-edpm --for condition=SetupReady --timeout=40m
+        edpm --for condition=SetupReady --timeout=40m
 
   - name: Dataplane Deployment
     manifest: manifests/dataplane/deployment.yaml
     wait_conditions:
-      - >-
-        oc wait -n openstack openstackdataplanedeployments.dataplane.openstack.org
-        dataplane --for condition=Ready --timeout=40m
-      - >-
-        timeout --foreground 15m hotstack-nova-discover-hosts
-        --namespace openstack --num-computes 3
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch run-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack openstackdataplanedeployment dataplane --for condition=Ready --timeout=10m
+      - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 3
 
   - name: Update openstack-operators OLM
     stages: >-

--- a/scenarios/sno-bmh-tests/manifests/dataplane/deployment.yaml
+++ b/scenarios/sno-bmh-tests/manifests/dataplane/deployment.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-  - openstack-edpm
+  - edpm

--- a/scenarios/sno-bmh-tests/manifests/dataplane/nodeset.yaml
+++ b/scenarios/sno-bmh-tests/manifests/dataplane/nodeset.yaml
@@ -2,7 +2,7 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm
+  name: edpm
   namespace: openstack
 spec:
   env:

--- a/scenarios/sno-bmh-tests/manifests/update/update-ovn.yaml
+++ b/scenarios/sno-bmh-tests/manifests/update/update-ovn.yaml
@@ -6,6 +6,6 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - ovn

--- a/scenarios/sno-bmh-tests/manifests/update/update-reboot.yaml
+++ b/scenarios/sno-bmh-tests/manifests/update/update-reboot.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - reboot-os
   ansibleExtraVars:

--- a/scenarios/sno-bmh-tests/manifests/update/update-services.yaml
+++ b/scenarios/sno-bmh-tests/manifests/update/update-services.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
+    - edpm
   servicesOverride:
     - update
     - reboot-os

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -80,10 +80,10 @@ stages:
   - name: Wait for nodesets (Networker and EDPM)
     wait_conditions:
       - >-
-        oc wait -n openstack openstackdataplanenodeset networker-nodes
+        oc wait -n openstack openstackdataplanenodeset networkers
         --for condition=SetupReady --timeout=10m
       - >-
-        oc -n openstack wait openstackdataplanenodeset openstack-edpm
+        oc -n openstack wait openstackdataplanenodeset edpm
         --for condition=SetupReady --timeout=10m
 
   - name: Networker deployment
@@ -94,15 +94,33 @@ stages:
 
   - name: Wait for deployments (Networker and EDPM)
     wait_conditions:
-      - >-
-        oc wait -n openstack openstackdataplanedeployment networker-deploy
-        --for condition=Ready --timeout=40m
-      - >-
-        oc -n openstack wait openstackdataplanedeployment edpm-deployment
-        --for condition=Ready --timeout=40m
-      - >-
-        timeout --foreground 15m hotstack-nova-discover-hosts
-        --namespace openstack --num-computes 3
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-networkers --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-networkers --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-networkers --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-networkers --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-networkers --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch run-os-dataplane-networkers --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch run-os-dataplane-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-networkers --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-networkers --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-networkers --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-networkers --for condition=Complete --timeout=10m
+      - oc wait -n openstack openstackdataplanedeployment networker-deploy --for condition=Ready --timeout=10m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch telemetry-dataplane-edpm --for condition=Complete --timeout=10m
+      - oc -n openstack wait openstackdataplanedeployment dataplane --for condition=Ready --timeout=10m
+      - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 3
 
   - name: "Minor update :: openstack-operators OLM"
     stages: >-

--- a/scenarios/uni01alpha/manifests/dataplane.yaml
+++ b/scenarios/uni01alpha/manifests/dataplane.yaml
@@ -2,8 +2,8 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: edpm-deployment
+  name: dataplane
   namespace: openstack
 spec:
   nodeSets:
-  - openstack-edpm
+  - edpm

--- a/scenarios/uni01alpha/manifests/edpm/edpm.yaml
+++ b/scenarios/uni01alpha/manifests/edpm/edpm.yaml
@@ -11,7 +11,7 @@ type: Opaque
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: openstack-edpm
+  name: edpm
   namespace: openstack
 spec:
   env:

--- a/scenarios/uni01alpha/manifests/networker/networker.yaml
+++ b/scenarios/uni01alpha/manifests/networker/networker.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-  - networker-nodes
+  - networkers

--- a/scenarios/uni01alpha/manifests/networker/nodeset/nodeset.yaml
+++ b/scenarios/uni01alpha/manifests/networker/nodeset/nodeset.yaml
@@ -11,7 +11,7 @@ type: Opaque
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneNodeSet
 metadata:
-  name: networker-nodes
+  name: networkers
   namespace: openstack
 spec:
   env:

--- a/scenarios/uni01alpha/manifests/update/update-ovn.yaml
+++ b/scenarios/uni01alpha/manifests/update/update-ovn.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
-    - networker-nodes
+    - edpm
+    - networkers
   servicesOverride:
     - ovn

--- a/scenarios/uni01alpha/manifests/update/update-reboot.yaml
+++ b/scenarios/uni01alpha/manifests/update/update-reboot.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
-    - networker-nodes
+    - edpm
+    - networkers
   servicesOverride:
     - reboot-os
   ansibleExtraVars:

--- a/scenarios/uni01alpha/manifests/update/update-services.yaml
+++ b/scenarios/uni01alpha/manifests/update/update-services.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: openstack
 spec:
   nodeSets:
-    - openstack-edpm
-    - networker-nodes
+    - edpm
+    - networkers
   servicesOverride:
     - update
     - reboot-os


### PR DESCRIPTION
Instead of waiting for the dataplane deployment, start waits for the individual jobs that are created. The idea is to fail, fast or atleast visually indicate failure fast.

In the future we might be able to use `break_when` in the ansible loop to get faster failure.