### PR TITLE
hotloop - no re-apply for unchanged manifest

### DIFF
--- a/roles/hotloop/library/hotloop_oc_apply_file.py
+++ b/roles/hotloop/library/hotloop_oc_apply_file.py
@@ -1,0 +1,190 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import os
+import filecmp
+import shutil
+from subprocess import Popen, PIPE, TimeoutExpired
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: hotloop_oc_apply_file
+
+short_description: Appy a manifest file to Kubernetes if different from backup
+
+version_added: "2.8"
+
+description:
+    - Replace the value of a path in a YAML file
+
+options:
+  file:
+    description:
+      - The manifest file to apply
+    type: str
+  backup:
+    description:
+      - The backup file to compare to
+    type: str
+    default: ''
+  timeout:
+    description:
+      - The timeout for the oc apply command
+    type: int
+    default: 60
+
+author:
+    - Harald Jensås <hjensas@redhat.com>
+"""
+
+EXAMPLES = r"""
+- name: Apply a manifest file to Kubernetes
+  hotloop_oc_apply_file:
+    file: foo.yaml'
+    backup: foo.yaml.backup
+    timeout: 30
+"""
+
+RETURN = r"""
+"""
+
+BACKUP_EXTENSION = ".previous"
+
+
+def apply_manifest(file, timeout=60):
+    """Apply a manifest file to Kubernetes.
+
+    :param file: The path to the Kubernetes manifest file.
+    :param timeout: The timeout for the oc apply command.
+    :returns: A tuple containing the return code, stdout, stderr, stdout lines, and stderr lines.
+    """
+    outs = str()
+    errs = str()
+
+    proc = Popen(["oc", "apply", "-f", file], stdout=PIPE, stderr=PIPE)
+    try:
+        outs, errs = proc.communicate(timeout=60)
+    except TimeoutExpired:
+        proc.kill()
+        outs, errs = proc.communicate()
+
+    rc = proc.returncode
+    outs = outs.decode("utf-8")
+    errs = errs.decode("utf-8")
+    out_lines = outs.splitlines()
+    err_lines = errs.splitlines()
+
+    return rc, outs, errs, out_lines, err_lines
+
+
+def create_backup(file):
+    """Create a backup of the file
+
+    Creates a backup of the given appending the
+    BACKUP_EXTENSION to its name.
+
+    :param file: The path to the file.
+    """
+    shutil.copy(file, file + BACKUP_EXTENSION)
+
+
+def no_diff(file):
+    """Check if the file is different from the backup file.
+
+    :param file: The path to the file.
+    :backup: The path to the backup file.
+    :returns: False if the file is different from the backup file, True otherwise.
+    """
+    if os.path.exists(file + BACKUP_EXTENSION) is False:
+        return False
+
+    return filecmp.cmp(file, file + BACKUP_EXTENSION)
+
+
+def run_module():
+    argument_spec = yaml.safe_load(DOCUMENTATION)["options"]
+    module = AnsibleModule(argument_spec, supports_check_mode=False)
+
+    result = dict(
+        success=False,
+        changed=False,
+        error="",
+        rc=int(),
+        stdout="",
+        stderr="",
+        stdout_lines=[],
+        stderr_lines=[],
+    )
+
+    file = module.params["file"]
+    timeout = module.params["timeout"]
+
+    try:
+
+        if no_diff(file):
+            result["msg"] = (
+                "Manifest {file} is not different from backup {backup}. No changes needed".format(
+                    file=file, backup=file + BACKUP_EXTENSION
+                )
+            )
+            result["success"] = True
+            result["changed"] = False
+            module.exit_json(**result)
+
+        rc, outs, errs, out_lines, err_lines = apply_manifest(file, timeout=timeout)
+
+        result["rc"] = rc
+        result["stdout"] = outs
+        result["stderr"] = errs
+        result["stdout_lines"] = out_lines
+        result["stderr_lines"] = err_lines
+
+        if rc == 0:
+            create_backup(file)
+            result["msg"] = "Manifest file {file} applied".format(file=file)
+            result["success"] = True
+            result["changed"] = True
+        else:
+            result["error"] = "Error while applying manifest file {file}".format(
+                file=file
+            )
+            module.fail_json(**result)
+
+        module.exit_json(**result)
+    except Exception as err:
+        result["error"] = str(err)
+        result["msg"] = (
+            "Error while trying to apply manifest file {file}: {err}".format(
+                file=file, err=err
+            )
+        )
+        module.fail_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/hotloop/tasks/static_manifest.yml
+++ b/roles/hotloop/tasks/static_manifest.yml
@@ -28,6 +28,7 @@
 
 - name: "Stage: {{ item.name }} :: Copy manifest"
   ansible.builtin.copy:
+    backup: true
     src: >-
       {{
         [
@@ -63,10 +64,8 @@
     loop_var: __patch
 
 - name: "Stage: {{ item.name }} :: Apply static manifest"
-  ansible.builtin.command:
-    chdir: "{{ manifests_dir }}"
-    cmd: >-
-      oc apply -f
+  hotloop_oc_apply_file:
+    file: >-
       {{
         [
           manifests_dir,

--- a/roles/hotloop/tasks/template_manifest.yml
+++ b/roles/hotloop/tasks/template_manifest.yml
@@ -62,11 +62,9 @@
     label: "{{ __patch.path }}"
     loop_var: __patch
 
-- name: "Stage: {{ item.name }} :: Apply dynamic manifest (Jinja2)"
-  ansible.builtin.command:
-    chdir: "{{ manifests_dir }}"
-    cmd: >-
-      oc apply -f
+- name: "Stage: {{ item.name }} :: Apply static manifest"
+  hotloop_oc_apply_file:
+    file: >-
       {{
         [
           manifests_dir,

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -112,8 +112,6 @@ stages:
     wait_conditions:
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh0"
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh1"
-    run_conditions:
-      - "{{ hotstack_skip_bmh is not defined }}"
 
   - name: Dataplane nodesets
     manifest: manifests/dataplane/nodesets.yaml

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -172,8 +172,6 @@ stages:
     wait_conditions:
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack-a --bmh bmh-a-0"
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack-b --bmh bmh-b-0"
-    run_conditions:
-      - "{{ hotstack_skip_bmh is not defined }}"
 
   - name: Dataplane nodeset
     manifest: manifests/dataplanes/nodesets.yaml

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -121,8 +121,6 @@ stages:
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh0"
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh1"
       - "timeout 5m hotstack-wait-for-bmh --namespace openstack --bmh bmh2"
-    run_conditions:
-      - "{{ hotstack_skip_bmh is not defined }}"
 
   - name: Dataplane nodeset
     manifest: manifests/dataplane/nodeset.yaml


### PR DESCRIPTION
Add module in hotloop library `hotloop_oc_apply_file`, this module will apply the manifest file using `oc apply -f <file>` command. If successful, a backup copy is created. On re-run the module will compare the backup and the new file. If there are no changes, it will not apply the manifest again.
    
Update static and template manifest task files to use the new module.
    
Also remove the run_condition on bmh tasks, it should not be needed now that the task applying manifest no longer re-applies unchanged manifests.
