### PR TITLE
Split dataplane deployment

### DIFF
--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -48,12 +48,15 @@ stages:
   - name: OpenstackControlPlane secrets
     manifest: manifests/control-plane/secrets.yaml
 
-  - name: OpenstackControlPlane
+  - name: Start OpenstackControlPlane deployment
     manifest: manifests/control-plane/control-plane.yaml
     wait_conditions:
       - >-
-        oc wait -n openstack openstackcontrolplane controlplane
-        --for condition=Ready --timeout=30m
+        oc -n openstack wait openstackcontrolplanes.core.openstack.org controlplane
+        --for condition=OpenStackControlPlaneDNSReadyCondition --timeout=600s
+      - >-
+        oc -n openstack wait openstackcontrolplanes.core.openstack.org controlplane
+        --for condition=OpenStackControlPlaneCAReadyCondition --timeout=600s
 
   - name: Dataplane SSH key secret
     shell: >-
@@ -92,24 +95,36 @@ stages:
         oc -n openstack wait openstackdataplanenodeset edpm
         --for condition=SetupReady --timeout=10m
 
-  - name: EDPM deployment
-    manifest: manifests/dataplane/deployment.yaml
+  - name: EDPM deployment - OperatingSystem
+    manifest: manifests/dataplane/deployment-os.yaml
     wait_conditions:
-      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm --for condition=Complete --timeout=1m
-      - oc wait -n openstack jobs.batch install-os-dataplane-edpm --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=1m
-      - oc wait -n openstack jobs.batch run-os-dataplane-edpm --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch ovn-dataplane-edpm --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm --for condition=Complete --timeout=20m
-      - oc wait -n openstack jobs.batch nova-dataplane-edpm --for condition=Complete --timeout=20m
-      - oc wait -n openstack jobs.batch telemetry-dataplane-edpm --for condition=Complete --timeout=10m
-      - oc wait -n openstack openstackdataplanedeployment dataplane --for condition=Ready --timeout=10m
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-os-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-os-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-os-edpm --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-os-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-os-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane-os --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch run-os-dataplane-os-edpm --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-os-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack openstackdataplanedeployment dataplane-os --for condition=Ready --timeout=10m
+
+  - name: Wait for OpentackControlPlane Setup Ready
+    manifest: manifests/control-plane/control-plane.yaml
+    wait_conditions:
+      - >-
+        oc wait -n openstack openstackcontrolplane controlplane
+        --for condition=Ready --timeout=30m
+
+  - name: EDPM deployment - Services
+    manifest: manifests/dataplane/deployment-services.yaml
+    wait_conditions:
+      - oc wait -n openstack jobs.batch install-certs-dataplane-services-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-services-edpm --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-services-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-services-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-services-edpm --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch telemetry-dataplane-services-edpm --for condition=Complete --timeout=10m
+      - oc wait -n openstack openstackdataplanedeployment dataplane-services --for condition=Ready --timeout=10m
       - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 1
 
   - name: Update openstack-operators OLM

--- a/scenarios/3-nodes/manifests/dataplane/deployment-os.yaml
+++ b/scenarios/3-nodes/manifests/dataplane/deployment-os.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: dataplane-os
+  namespace: openstack
+spec:
+  nodeSets:
+  - edpm
+  servicesOverride:
+  - bootstrap
+  - configure-network
+  - validate-network
+  - install-os
+  - configure-os
+  - ssh-known-hosts
+  - run-os
+  - reboot-os

--- a/scenarios/3-nodes/manifests/dataplane/deployment-services.yaml
+++ b/scenarios/3-nodes/manifests/dataplane/deployment-services.yaml
@@ -2,8 +2,15 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: dataplane
+  name: dataplane-services
   namespace: openstack
 spec:
   nodeSets:
   - edpm
+  servicesOverride:
+  - install-certs
+  - ovn
+  - neutron-metadata
+  - libvirt
+  - nova
+  - telemetry

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -57,12 +57,15 @@ stages:
   - name: OpenstackControlPlane secrets
     manifest: manifests/control-plane/secrets.yaml
 
-  - name: OpenstackControlPlane
+  - name: Start OpenstackControlPlane deployment
     manifest: manifests/control-plane/control-plane.yaml
     wait_conditions:
       - >-
-        oc wait -n openstack openstackcontrolplane controlplane
-        --for condition=Ready --timeout=60m
+        oc -n openstack wait openstackcontrolplanes.core.openstack.org controlplane
+        --for condition=OpenStackControlPlaneDNSReadyCondition --timeout=600s
+      - >-
+        oc -n openstack wait openstackcontrolplanes.core.openstack.org controlplane
+        --for condition=OpenStackControlPlaneCAReadyCondition --timeout=600s
 
   - name: Dataplane SSH key secret
     shell: >-
@@ -124,35 +127,46 @@ stages:
         oc wait -n openstack openstackdataplanenodesets.dataplane.openstack.org
         edpm-b --for condition=SetupReady --timeout=40m
 
-  - name: Dataplane Deployment
-    manifest: manifests/dataplane/deployment.yaml
+  - name: Dataplane Deployment - Step 1
+    manifest: manifests/dataplane/deployment-step1.yaml
     wait_conditions:
-      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm-a --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch bootstrap-dataplane-edpm-b --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm-a --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch configure-network-dataplane-edpm-b --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm-a --for condition=Complete --timeout=1m
-      - oc wait -n openstack jobs.batch validate-network-dataplane-edpm-b --for condition=Complete --timeout=1m
-      - oc wait -n openstack jobs.batch install-os-dataplane-edpm-a --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch install-os-dataplane-edpm-b --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm-a --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch configure-os-dataplane-edpm-b --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane --for condition=Complete --timeout=2m
-      - oc wait -n openstack jobs.batch run-os-dataplane-edpm-a --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch run-os-dataplane-edpm-b --for condition=Complete --timeout=3m
-      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm-a --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch reboot-os-dataplane-edpm-b --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm-a --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch install-certs-dataplane-edpm-b --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch ovn-dataplane-edpm-a --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch ovn-dataplane-edpm-b --for condition=Complete --timeout=5m
-      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm-a --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-edpm-b --for condition=Complete --timeout=10m
-      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm-a --for condition=Complete --timeout=20m
-      - oc wait -n openstack jobs.batch libvirt-dataplane-edpm-b --for condition=Complete --timeout=20m
-      - oc wait -n openstack jobs.batch nova-dataplane-edpm-a --for condition=Complete --timeout=20m
-      - oc wait -n openstack jobs.batch nova-dataplane-edpm-b --for condition=Complete --timeout=20m
-      - oc wait -n openstack openstackdataplanedeployment dataplane --for condition=Ready --timeout=10m
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-step-1-edpm-a --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch bootstrap-dataplane-step-1-edpm-b --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-step-1-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-network-dataplane-step-1-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-step-1-edpm-a --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch validate-network-dataplane-step-1-edpm-b --for condition=Complete --timeout=1m
+      - oc wait -n openstack jobs.batch install-os-dataplane-step-1-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-os-dataplane-step-1-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-step-1-edpm-a --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch configure-os-dataplane-step-1-edpm-b --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch ssh-known-hosts-dataplane-step-1 --for condition=Complete --timeout=2m
+      - oc wait -n openstack jobs.batch run-os-dataplane-step-1-edpm-a --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch run-os-dataplane-step-1-edpm-b --for condition=Complete --timeout=3m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-step-1-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch reboot-os-dataplane-step-1-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack openstackdataplanedeployment dataplane-step-1 --for condition=Ready --timeout=10m
+
+  - name: Wait for OpentackControlPlane Setup Ready
+    wait_conditions:
+      - >-
+        oc wait -n openstack openstackcontrolplane controlplane
+        --for condition=Ready --timeout=60m
+
+  - name: Dataplane Deployment - Step 2
+    manifest: manifests/dataplane/deployment-step2.yaml
+    wait_conditions:
+      - oc wait -n openstack jobs.batch install-certs-dataplane-step-2-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch install-certs-dataplane-step-2-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-step-2-edpm-a --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch ovn-dataplane-step-2-edpm-b --for condition=Complete --timeout=5m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-step-2-edpm-a --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch neutron-metadata-dataplane-step-2-edpm-b --for condition=Complete --timeout=10m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-step-2-edpm-a --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch libvirt-dataplane-step-2-edpm-b --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-step-2-edpm-a --for condition=Complete --timeout=20m
+      - oc wait -n openstack jobs.batch nova-dataplane-step-2-edpm-b --for condition=Complete --timeout=20m
+      - oc wait -n openstack openstackdataplanedeployment dataplane-step-2 --for condition=Ready --timeout=10m
       - timeout --foreground 15m hotstack-nova-discover-hosts --namespace openstack --num-computes 2
 
   - name: Update openstack-operators OLM

--- a/scenarios/multi-nodeset/manifests/control-plane/control-plane.yaml
+++ b/scenarios/multi-nodeset/manifests/control-plane/control-plane.yaml
@@ -75,7 +75,7 @@ spec:
               metallb.universe.tf/loadBalancerIPs: 192.168.122.80
           spec:
             type: LoadBalancer
-      replicas: 1
+      replicas: 2
   galera:
     enabled: true
     templates:

--- a/scenarios/multi-nodeset/manifests/dataplane/deployment-step1.yaml
+++ b/scenarios/multi-nodeset/manifests/dataplane/deployment-step1.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneDeployment
+metadata:
+  name: dataplane-step-1
+  namespace: openstack
+spec:
+  nodeSets:
+  - edpm-a
+  - edpm-b
+  servicesOverride:
+  - bootstrap
+  - configure-network
+  - validate-network
+  - install-os
+  - configure-os
+  - ssh-known-hosts
+  - run-os
+  - reboot-os

--- a/scenarios/multi-nodeset/manifests/dataplane/deployment-step2.yaml
+++ b/scenarios/multi-nodeset/manifests/dataplane/deployment-step2.yaml
@@ -2,9 +2,15 @@
 apiVersion: dataplane.openstack.org/v1beta1
 kind: OpenStackDataPlaneDeployment
 metadata:
-  name: dataplane
+  name: dataplane-step-2
   namespace: openstack
 spec:
   nodeSets:
   - edpm-a
   - edpm-b
+  servicesOverride:
+  - install-certs
+  - ovn
+  - neutron-metadata
+  - libvirt
+  - nova


### PR DESCRIPTION
Split the dataplane deployment into two deployments. One does the bootstrap and OS part, the other OVN Openstack services.

When creating the OpenstackControlplane - initially wait only for `dns` and `OpenStackControlPlaneCAReadyCondition` conditions. Then move on and start the dataplane step 1. Once dataplane step 1 is complete, wait for OpenstackControlplane to be Ready before starting dataplane step 2.