### PR TITLE
Add retry to Extract ingress CA cert task

### DIFF
--- a/roles/ocp_agent_installer/tasks/ingress_cert.yml
+++ b/roles/ocp_agent_installer/tasks/ingress_cert.yml
@@ -20,6 +20,9 @@
     POD_NAME=$({{ bin_dir }}/oc get pods -n openshift-authentication -o jsonpath='{.items[0].metadata.name}')
     {{ bin_dir }}/oc rsh -n openshift-authentication $POD_NAME \
       cat /run/secrets/kubernetes.io/serviceaccount/ca.crt
+  retries: 10
+  delay: 10
+  until: _ingress_cert.rc == 0
 
 - name: Write ingress cert to ca-trust
   become: true


### PR DESCRIPTION
Started seeing this error:
`Error from server (BadRequest): pod oauth-openshift-668d6f56cf-tcz5z does not have a host assigned`

On re-run it works ...