### PR TITLE
Add OCP cluster snapshot and restore capabilities

### DIFF
--- a/04-create-snapset.yml
+++ b/04-create-snapset.yml
@@ -14,13 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-hotlog_dir: "{{ playbook_dir }}/logs"
+- name: Create Hotstack SnapSet
+  hosts: localhost
+  gather_facts: true
+  strategy: linear
+  pre_tasks:
+    - name: Load stack output vars from file
+      ansible.builtin.include_vars:
+        file: "{{ hotstack_work_dir | default(playbook_dir) }}/{{ stack_name }}-outputs.yaml"
+        name: stack_outputs
 
-base_dir: /home/zuul
-ocp_agent_installer_cluster_dir: "{{ base_dir }}/ocp-cluster"
-
-hotlog_collect_paths:
-  - "{{ ocp_agent_installer_cluster_dir }}/.openshift_install.log"
-  - "{{ base_dir }}/cluster-custom-config"
-  - "{{ base_dir }}/data"
-  - "{{ base_dir }}/manifests"
+  roles:
+    - role: hot_snapset
+      vars:
+        controller_ansible_host: "{{ stack_outputs.controller_ansible_host }}"
+        snapset_data: "{{ stack_outputs.snapset_data }}"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ to install OCP.
 
 ## TODO
 
-* Add more scenarios, for other arhcitectures
-* Figure out snapshots of OCP + automate the process
 * IPv6
 
 ## Pre-requisites
@@ -117,6 +115,7 @@ hotstack_cloud_secrets:
 ### Ansible collections (Dependencies)
 
 ```bash
+ansible-galaxy collection install community.general
 ansible-galaxy collection install community.crypto
 ansible-galaxy collection install openstack.cloud
 ```

--- a/ci/playbooks/pre-commit.yml
+++ b/ci/playbooks/pre-commit.yml
@@ -19,6 +19,7 @@
           - ansible-core
     - name: Install ansible galaxy dependencies
       ansible.builtin.shell: |
+        {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install community.general
         {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install community.crypto
         {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install openstack.cloud
     - name: Run pre-commit

--- a/create-snapset.yml
+++ b/create-snapset.yml
@@ -14,13 +14,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-hotlog_dir: "{{ playbook_dir }}/logs"
+- name: Bootstrap virtual infrastructure on Openstack cloud
+  ansible.builtin.import_playbook: 01-infra.yml
 
-base_dir: /home/zuul
-ocp_agent_installer_cluster_dir: "{{ base_dir }}/ocp-cluster"
+- name: Bootstrap controller node
+  ansible.builtin.import_playbook: 02-bootstrap_controller.yml
 
-hotlog_collect_paths:
-  - "{{ ocp_agent_installer_cluster_dir }}/.openshift_install.log"
-  - "{{ base_dir }}/cluster-custom-config"
-  - "{{ base_dir }}/data"
-  - "{{ base_dir }}/manifests"
+- name: Install Openshift Container Platform
+  vars:
+    ocp_agent_installer_prep_for_snapshot: true
+  ansible.builtin.import_playbook: 03-install_ocp.yml
+
+- name: Create Hotstack SnapSet
+  ansible.builtin.import_playbook: 04-create-snapset.yml

--- a/docs/deploy_hotstack_on_psi.md
+++ b/docs/deploy_hotstack_on_psi.md
@@ -111,9 +111,10 @@ pip install ansible
 
 HotStack depends on specific Ansible collections that provide modules for
 interacting with OpenStack and performing cryptographic operations. Install
-`community.crypto` and `openstack.cloud` collections.
+`community.general`, `community.crypto` and `openstack.cloud` collections.
 
 ```bash
+ansible-galaxy collection install community.general
 ansible-galaxy collection install community.crypto
 ansible-galaxy collection install openstack.cloud
 ```

--- a/docs/hotstack_snapset.md
+++ b/docs/hotstack_snapset.md
@@ -1,0 +1,269 @@
+# Hotstack SnapSet Feature
+
+## Overview
+
+The Hotstack SnapSet feature enables creating consistent snapshots of OpenStack
+instances (virtual machines) in a running Hotstack deployment. This feature is
+particularly useful for:
+
+- **Development and Testing**: Create snapshots of fully deployed OpenShift
+  clusters to quickly restore to a known good state
+- **CI/CD Pipelines**: Reduce deployment time by starting from pre-configured
+  snapshots instead of deploying from scratch
+
+## What is a SnapSet?
+
+A SnapSet is a collection of OpenStack images created from running instances at a
+specific point in time. Each SnapSet contains:
+
+- **Controller Node Image**: Snapshot of the Hotstack controller instance
+- **OpenShift Node Images**: Snapshots of OpenShift master/worker nodes
+- **Metadata**: Information about each instance including role, MAC addresses,
+  and unique identifiers
+
+All images in a SnapSet are tagged with a unique identifier and metadata for
+easy identification and management.
+
+## How SnapSet Works
+
+The SnapSet creation process involves several steps:
+
+1. **Cluster Preparation**: OpenShift nodes are cordoned (marked unschedulable)
+   to prevent new workloads
+2. **Graceful Shutdown**: All instances are gracefully shut down
+3. **Image Creation**: OpenStack images are created from each stopped instance
+4. **Metadata Tagging**: Each image is tagged with relevant metadata for
+   identification
+5. **Parallel Processing**: Multiple images are created concurrently for
+   efficiency
+
+The process ensures data consistency by stopping all instances before creating
+snapshots.
+
+### Important: Bootstrap Certificate Rotation
+
+OpenShift 4 clusters have a critical requirement related to certificate
+rotation that affects when snapshots can be safely created. When a cluster is
+installed, a bootstrap certificate is created for kubelet client certificate
+requests. This bootstrap certificate expires after 24 hours and cannot be
+renewed.
+
+If a cluster is shut down before the initial 24-hour certificate rotation
+completes and the 30-day client certificates are issued, the cluster becomes
+unusable when restarted because the expired bootstrap certificate cannot
+authenticate the kubelets.
+
+**This is why Hotstack waits 25 hours before creating snapshots** - to ensure
+the certificate rotation has completed and the cluster can be safely shut down
+and restarted without requiring manual certificate signing request (CSR)
+approval or other workarounds.
+
+For more technical details, see the [Red Hat blog post on enabling OpenShift 4
+clusters to stop and resume](https://www.redhat.com/en/blog/enabling-openshift-4-clusters-to-stop-and-resume-cluster-vms).
+
+## Creating a SnapSet
+
+### Using the Automated Playbook
+
+The simplest way to create a SnapSet is using the provided playbook and
+scenario:
+
+```bash
+ansible-playbook -i inventory.yml create-snapset.yml \
+  -e @scenarios/snapshot-sno/bootstrap_vars.yml \
+  -e @~/bootstrap_vars_overrides.yml \
+  -e @~/cloud-secrets.yaml
+```
+
+This playbook performs the complete workflow:
+
+1. **Infrastructure Setup** (`01-infra.yml`)
+2. **Controller Bootstrap** (`02-bootstrap_controller.yml`)
+3. **OpenShift Installation** (`03-install_ocp.yml`) - with snapshot
+   preparation
+4. **SnapSet Creation** (`04-create-snapset.yml`)
+
+### Using Individual Playbooks
+
+You can also run playbooks individually for more control:
+
+```bash
+# Only create snapset from existing deployment
+ansible-playbook -i inventory.yml 04-create-snapset.yml \
+  -e @scenarios/snapshot-sno/bootstrap_vars.yml \
+  -e @~/bootstrap_vars_overrides.yml \
+  -e @~/cloud-secrets.yaml
+```
+
+### Configuration Variables
+
+Key configuration variables for SnapSet creation:
+
+```yaml
+# Enable snapshot preparation during OCP installation
+ocp_agent_installer_prepare_for_snapshot: true
+```
+
+## SnapSet Process Details
+
+### Preparation Phase
+
+When `ocp_agent_installer_prepare_for_snapshot` is enabled:
+
+1. **Bootstrap Certificate Wait**: The system waits 25 hours to allow OpenShift's
+   bootstrap certificate rotation to complete. This ensures that 30-day client
+   certificates are properly issued, eliminating the need for manual certificate
+   signing request (CSR) approval or daemonset workarounds when the cluster is
+   later restored from snapshots.
+2. **Cluster Stabilization**: Waits for cluster to be stable for the specified
+   period
+3. **Node Cordoning**: Marks all nodes as unschedulable
+4. **Graceful Shutdown**: Shuts down all OpenShift nodes
+
+### Image Creation Phase
+
+The `hotstack_snapset` Ansible module:
+
+1. **Validates Input**: Ensures all required instance data is provided
+2. **Checks Instance States**: Verifies all instances are in SHUTOFF state
+3. **Creates Images**: Parallel creation of OpenStack images from instances
+4. **Tags Images**: Adds metadata tags to each created image
+
+### Generated Image Names and Tags
+
+Created images follow the naming convention:
+
+```text
+hotstack-{instance_name}-snapshot-{unique_id}
+```
+
+Each image is tagged with:
+
+- `hotstack`: General Hotstack identifier
+- `name={name}`: Instance name
+- `role={role}`: Instance role (controller, ocp_master, etc.)
+- `snap_id={unique_id}`: Unique snapshot set identifier
+- `mac_address={mac}`: Original MAC address
+
+## Using SnapSet Images
+
+### Identifying SnapSet Images
+
+List available snapset images:
+
+```bash
+openstack image list --tag hotstack
+```
+
+Find images from a specific snapset:
+
+```bash
+openstack image list --tag snap_id=AbCdEf
+```
+
+### Restoring from SnapSet
+
+To restore an environment from a SnapSet:
+
+1. **Update Bootstrap Variables**: Modify the `stack_parameters` in your
+   bootstrap_vars.yml file to use snapset images instead of base images
+2. **Preserve MAC Addresses**: Ensure MAC addresses match those in the snapset
+3. **Deploy Stack**: Deploy the Heat stack with snapset images
+4. **Revive Cluster**: Use the revive functionality to restore OpenShift
+   cluster state
+
+### Reviving OpenShift Clusters
+
+When booting from snapset images, use the revive mode:
+
+```yaml
+# In bootstrap_vars.yml
+ocp_agent_installer_revive_snapshot: true
+```
+
+The revive process:
+
+1. **Initial Stability Check**: Waits for basic cluster stability
+2. **Uncordon Nodes**: Marks nodes as schedulable again
+3. **Extended Stability**: Waits for full cluster stability (multiple rounds)
+4. **Service Restoration**: Ensures all services are operational
+
+## SnapSet Data Structure
+
+The snapset data follows this structure:
+
+```yaml
+snapset_data:
+  instances:
+    controller:
+      uuid: "instance-uuid"
+      role: "controller"
+      mac_address: "fa:16:9e:81:f6:5"
+    master0:
+      uuid: "instance-uuid"
+      role: "ocp_master"
+      mac_address: "fa:16:9e:81:f6:10"
+```
+
+## Example: Complete SnapSet Workflow
+
+### 1. Create SnapSet
+
+```bash
+# Deploy and create snapset
+ansible-playbook -i inventory.yml create-snapset.yml \
+  -e @scenarios/snapshot-sno/bootstrap_vars.yml \
+  -e @~/my_overrides.yml \
+  -e @~/cloud-secrets.yaml
+```
+
+### 2. Verify SnapSet Creation
+
+```bash
+# List created images
+openstack image list --tag hotstack
+
+# Check specific snapset
+openstack image list --tag snap_id=AbCdEf
+```
+
+### 3. Use SnapSet Images
+
+Update your bootstrap_vars.yml file or create an override file to use snapset images:
+
+```yaml
+# In bootstrap_vars.yml
+stack_parameters:
+  controller_params:
+    image: hotstack-controller-snapshot-AbCdEf
+    flavor: hotstack.small
+  ocp_master_params:
+    image: hotstack-master0-snapshot-AbCdEf
+    flavor: hotstack.xxlarge
+```
+
+### 4. Deploy a SNO scenario from SnapSet
+
+```bash
+# Deploy using snapset images
+ansible-playbook -i inventory.yml bootstrap.yml \
+  -e @scenarios/sno-bmh-tests/bootstrap_vars.yml \
+  -e @~/cloud-secrets.yaml \
+  -e ocp_agent_installer_revive_snapshot=true
+```
+
+## Limitations
+
+- **Certificate Rotation**: SnapSets must be used within 30 days due to
+  OpenShift's certificate rotation cycle. After 30 days, the cluster may
+  require additional certificate management procedures
+
+## Related Documentation
+
+- [Hotstack Scenarios](hotstack_scenarios.md)
+- [OpenStack Image Management](https://docs.openstack.org/glance/latest/)
+- [OpenShift Cluster Management](
+  https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-managing.html)
+- [Enabling OpenShift 4 Clusters to Stop and Resume Cluster VMs](
+  https://www.redhat.com/en/blog/enabling-openshift-4-clusters-to-stop-and-resume-cluster-vms)
+  (Red Hat blog post explaining the bootstrap certificate issue)

--- a/roles/controller/files/bin/hotstack-snapset
+++ b/roles/controller/files/bin/hotstack-snapset
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -Eeuo pipefail
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+NODES=
+STABLE_PERIODS=()
+PERIOD_IDX=0
+COMMANDS=()
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+source "${SCRIPTPATH}"/hotstack-common-funcs.sh
+
+function usage {
+    echo
+    echo "Utilities for preparing and reviving OCP snapshots"
+    echo
+    echo "Executes the specified operations sequentially in the order they"
+    echo "appear on the command line. This allows combining multiple"
+    echo "operations like waiting for stability, then cordoning nodes, then"
+    echo "shutting down - all in a single command with proper sequencing."
+    echo
+    echo "Any option can be specified multiple times, allowing for complex"
+    echo "workflows like:"
+    echo "  --wait-cluster-stable 10s --uncordon --wait-cluster-stable 1m"
+    echo
+    echo "options:"
+    echo "  --wait-cluster-stable <number><s|m> Wait for cluster to be stable for the minimum period"
+    echo "  --cordon                            Mark nodes unschedulable"
+    echo "  --uncordon                          Mark nodes schedulable"
+    echo "  --shutdown                          Shutdown the OCP nodes"
+    echo "  --wait-for-api-versions-route       Wait for the route API version to be available"
+    echo
+}
+
+function wait_stable {
+    wait_for_stable_cluster "${STABLE_PERIODS[${PERIOD_IDX}]}" || exit 1
+    (( PERIOD_IDX += 1 ))
+}
+
+function wait_route {
+    wait_for_api_versions_route || exit 1
+}
+
+function cordon {
+    [ -z "${NODES}" ] && NODES="$(get_ocp_nodes)"
+    cordon_ocp_nodes "${NODES}" || exit 1
+}
+
+function uncordon {
+    [ -z "${NODES}" ] && NODES="$(get_ocp_nodes)"
+    uncordon_ocp_nodes "${NODES}" || exit 1
+}
+
+function shutdown {
+    [ -z "${NODES}" ] && NODES="$(get_ocp_nodes)"
+    shutdown_ocp_nodes "${NODES}" || exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        "--wait-cluster-stable")
+            if ! [[ "$2" =~ ^[0-9]+[sm]$ ]]
+            then
+                echo "Minimum stable period is required in the format of <number><s|m>"
+                usage
+                exit 1
+            fi
+            STABLE_PERIODS+=("$2");
+            COMMANDS+=("wait_stable");
+            shift
+        ;;
+        "--cordon")
+            COMMANDS+=("cordon");
+        ;;
+        "--uncordon")
+            COMMANDS+=("uncordon");
+        ;;
+        "--shutdown")
+            COMMANDS+=("shutdown");
+        ;;
+        "--wait-for-api-versions-route")
+            COMMANDS+=("wait_route");
+        ;;
+        *)
+            echo "Unknown parameter passed: $1";
+            usage
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+if [ ${#COMMANDS[@]} -eq 0 ]
+then
+    echo "Not enough arguments"
+    usage
+    exit 1
+fi
+
+# Run the commands in the order they were passed in
+for cmd in "${COMMANDS[@]}"; do
+    "$cmd"
+done
+
+exit 0

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -67,11 +67,13 @@
         - bin/hotstack-approve-install-plan
         - bin/hotstack-leader-election-tune
         - bin/hotstack-nova-discover-hosts
+        - bin/hotstack-snapset
         - bin/hotstack-openstack-version-patch
         - bin/hotstack-wait-for-bmh
 
     - name: Write ansible inventory to file on controller-0
       when:
+        - ansible_inventory is defined
         - ansible_inventory | length > 0
       ansible.builtin.copy:
         content: "{{ ansible_inventory | to_nice_yaml(indent=2) }}"

--- a/roles/hot_snapset/README.md
+++ b/roles/hot_snapset/README.md
@@ -1,0 +1,157 @@
+# hot_snapset - ansible role
+
+## Overview
+
+The `hot_snapset` role creates consistent snapshots of OpenStack instances in a
+Hotstack deployment. It safely shuts down instances and creates OpenStack images
+from them, enabling rapid deployment restoration and development workflows.
+
+## Purpose
+
+This role is designed to:
+
+- Create consistent point-in-time snapshots of running OpenStack instances
+- Safely shutdown instances before snapshot creation to ensure data integrity
+- Generate uniquely tagged OpenStack images for easy identification and management
+- Support parallel image creation for efficient processing
+- Enable quick restoration of complex OpenShift deployments
+
+## Requirements
+
+- OpenStack cloud environment with image creation capabilities
+- Python `openstack` library installed
+- Ansible collections:
+  - `openstack.cloud`
+  - `community.general`
+- Instances to be snapshotted must be in SHUTOFF state
+
+## Role Variables
+
+### Required Variables
+
+- `snapset_data` (dict): Instance data structure containing instances to snapshot
+- `controller_ansible_host` (dict): Ansible host information for the controller node
+
+### Optional Variables
+
+- `hotstack_work_dir` (string): Working directory for hotstack operations
+  - Default: `"{{ playbook_dir }}"`
+- `os_cloud` (string): OpenStack cloud name from clouds.yaml
+  - Default: `"{{ lookup('ansible.builtin.env', 'OS_CLOUD') }}"`
+
+### snapset_data Structure
+
+```yaml
+snapset_data:
+  instances:
+    controller:
+      uuid: "instance-uuid"
+      role: "controller"
+      mac_address: "fa:16:9e:81:f6:5"
+    master0:
+      uuid: "instance-uuid"
+      role: "ocp_master"
+      mac_address: "fa:16:9e:81:f6:10"
+```
+
+Each instance must have:
+
+- `uuid`: OpenStack instance UUID
+- `role`: Instance role (controller, ocp_master, etc.)
+- `mac_address`: MAC address for network identification
+
+## Dependencies
+
+- `openstack.cloud` collection
+- `community.general` collection
+
+## How It Works
+
+1. **Validation**: Validates required variables and snapset data structure
+2. **Controller Shutdown**: Adds controller to inventory and shuts it down gracefully
+3. **State Verification**: Waits for all instances to reach SHUTOFF state
+4. **Image Creation**: Creates OpenStack images from instances in parallel
+5. **Tagging**: Tags images with metadata for identification
+
+## Generated Images
+
+Created images follow the naming convention:
+
+```text
+hotstack-{instance_name}-snapshot-{unique_id}
+```
+
+Each image is tagged with:
+
+- `hotstack`: General hotstack identifier
+- `name={name}`: Instance name
+- `role={role}`: Instance role
+- `snap_id={unique_id}`: Unique snapshot set identifier
+- `mac_address={mac}`: Original MAC address
+
+## Example Playbook
+
+```yaml
+---
+- name: Create Hotstack SnapSet
+  hosts: localhost
+  gather_facts: true
+  roles:
+    - role: hot_snapset
+      vars:
+        controller_ansible_host:
+          name: "controller"
+          ansible_host: "192.168.1.100"
+          ansible_user: "cloud-user"
+          ansible_ssh_private_key_file: "~/.ssh/id_rsa"
+        snapset_data:
+          instances:
+            controller:
+              uuid: "6f4512de-f744-4979-8ab2-45f5461e304c"
+              role: "controller"
+              mac_address: "fa:16:9e:81:f6:5"
+            master0:
+              uuid: "7a5623ef-g855-5a8a-9bc3-56g6572f415d"
+              role: "ocp_master"
+              mac_address: "fa:16:9e:81:f6:10"
+```
+
+## Integration with Hotstack
+
+This role is typically used as part of the complete hotstack snapshot workflow:
+
+```bash
+# Create full deployment with snapshots
+ansible-playbook -i inventory.yml create-snapset.yml \
+  -e @scenarios/snapshot-sno/bootstrap_vars.yml \
+  -e @~/bootstrap_vars_overrides.yml \
+  -e @~/cloud-secrets.yaml
+```
+
+The role is called from `04-create-snapset.yml` playbook after:
+
+1. Infrastructure setup (`01-infra.yml`)
+2. Controller bootstrap (`02-bootstrap_controller.yml`)
+3. OpenShift installation with snapshot preparation (`03-install_ocp.yml`)
+
+## Custom Module
+
+The role includes a custom Ansible module `hotstack_snapset` that handles:
+
+- OpenStack connection management
+- Instance state validation
+- Parallel image creation with threading
+- Image tagging and metadata management
+- Error handling and validation
+
+## Notes
+
+- All instances must be in SHUTOFF state before snapshot creation
+- The role uses parallel processing to create multiple images simultaneously
+- Images are created with a unique identifier to group them as a set
+- Controller node is gracefully shut down as part of the process
+- Snapshots preserve MAC addresses and role information for restoration
+
+## Author
+
+Harald Jensås <hjensas@redhat.com>

--- a/roles/hot_snapset/defaults/main.yml
+++ b/roles/hot_snapset/defaults/main.yml
@@ -14,13 +14,5 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-hotlog_dir: "{{ playbook_dir }}/logs"
-
-base_dir: /home/zuul
-ocp_agent_installer_cluster_dir: "{{ base_dir }}/ocp-cluster"
-
-hotlog_collect_paths:
-  - "{{ ocp_agent_installer_cluster_dir }}/.openshift_install.log"
-  - "{{ base_dir }}/cluster-custom-config"
-  - "{{ base_dir }}/data"
-  - "{{ base_dir }}/manifests"
+hotstack_work_dir: "{{ playbook_dir }}"
+os_cloud: "{{ lookup('ansible.builtin.env', 'OS_CLOUD') }}"

--- a/roles/hot_snapset/library/hotstack_snapset.py
+++ b/roles/hot_snapset/library/hotstack_snapset.py
@@ -1,0 +1,318 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import base64
+from concurrent import futures
+import os
+import sys
+import yaml
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import errors as ansible_exc
+
+try:
+    import openstack
+    from openstack import exceptions as os_exc
+
+    HAS_OPENSTACK = True
+except ImportError:
+    HAS_OPENSTACK = False
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: hotstack_snapset
+
+short_description: Create snapshot resource set from instances
+version_added: "2.8"
+
+description:
+    - Create snapshot resource set from instances
+
+options:
+  cloud:
+    description:
+      - Openstack cloud name
+  snapset_data:
+    description:
+      - Instances to snapshot and metadata about them
+    type: dict
+
+author:
+    - Harald Jensås <hjensas@redhat.com>
+"""
+
+EXAMPLES = r"""
+- name: Create snapshot of instances and volumes
+  hotstack_snapset:
+    snapset_data:
+      instances:
+        controller:
+            hotstack_role: controller
+            uuid: 6f4512de-f744-4979-8ab2-45f5461e304c
+            mac_address: "fa:16:9e:81:f6:5"
+        master0:
+            hotstack_role: ocp_master
+            uuid: 6f4512de-f744-4979-8ab2-45f5461e304c
+            mac_address: "fa:16:9e:81:f6:10"
+"""
+
+RETURN = r"""
+snapset:
+  snap_id:
+    description: Uniq ID of the created snapshot
+  controller:
+    image_id:
+      description: ID of the created image
+      type: str
+    role:
+      description: Role of the server
+      type: str
+    mac_address:
+      description: MAC address of the server
+      type: str
+  master0:
+    image_id:
+      description: ID of the created image
+      type: str
+    role:
+      description: Role of the server
+      type: str
+    mac_address:
+      description: MAC address of the server
+      type: str
+"""
+
+INSTANCE_REQUIRED_KEYS = {
+    "role",
+    "uuid",
+    "mac_address",
+}
+
+INSTANCE_ALLOWED_KEYS = INSTANCE_REQUIRED_KEYS
+
+SERVER_SHUTOFF = "SHUTOFF"
+
+
+def _create_image_from_server(conn, name, uuid, role, mac_address, uniq):
+    """Create image from server
+
+    This function creates an image from an existing server using the
+    OpenStack Nova API. It tags the newly created image with 'name',
+    'role', 'uniq_id', and 'mac_address' for easy identification.
+
+    :param conn: openstack connection
+    :param name: name of server
+    :param uuid: uuid of server
+    :param role: role of server
+    :param mac_address: mac address of server
+    :param uniq: unique id
+    :return: image id
+    """
+    image_name = "hotstack-" + name + "-snapshot-" + uniq
+    image = conn.compute.create_server_image(uuid, image_name, wait=True, timeout=900)
+    conn.image.add_tag(image, "hotstack")
+    conn.image.add_tag(image, "name=" + name)
+    conn.image.add_tag(image, "role=" + role)
+    conn.image.add_tag(image, "snap_id=" + uniq)
+    conn.image.add_tag(image, "mac_address=" + mac_address)
+
+    result = dict()
+    result[name] = dict()
+    result[name]["image_id"] = image.id
+    result[name]["role"] = role
+    result[name]["mac_address"] = mac_address
+
+    return result
+
+
+def create_snapset(conn, instances):
+    """Create snapshot resource set from instances
+
+    :param conn: openstack connection
+    :param instances: instances to snapshot
+    :return: snapshot resource set
+    """
+    uniq = base64.urlsafe_b64encode(os.urandom(6)).decode("utf-8")
+    snapset = dict()
+    snapset["snap_id"] = uniq
+
+    jobs = []
+    with futures.ThreadPoolExecutor(max_workers=4) as p:
+
+        for name, data in instances.items():
+            uuid = data["uuid"]
+            role = data["role"]
+            mac_address = data["mac_address"]
+            jobs.append(
+                p.submit(
+                    _create_image_from_server, conn, name, uuid, role, mac_address, uniq
+                )
+            )
+
+    for job in futures.as_completed(jobs):
+        e = job.exception()
+        if e:
+            raise e
+        else:
+            snapset.update(job.result())
+
+    return snapset
+
+
+def validate_servers_state(servers):
+    """Validate that all server are in the required SHUTOFF state.
+
+    :param servers: list of servers to validate
+    :raises: AnsibleValidationError - if any of the servers are not in the required state
+    """
+    for server in servers:
+        if server.status != SERVER_SHUTOFF:
+            raise ansible_exc.AnsibleValidationError(
+                "instance {server} is not in the {required_state} state".format(
+                    server=server.id, requiered_state=SERVER_SHUTOFF
+                )
+            )
+
+
+def get_servers(conn, instances):
+    """Get instances from openstack
+
+    :param conn: openstack connection
+    :param instances: instances to get
+    :return: list of servers
+    :raises: AnsibleValidationError - if any of the instances are not found in the openstack cloud
+    """
+    servers = list()
+    for _, v in instances.items():
+        try:
+            servers.append(conn.compute.get_server(v["uuid"]))
+        except os_exc.ResourceNotFound:
+            raise ansible_exc.AnsibleValidationError(
+                "instance {instance} is not found in the openstack cloud".format(
+                    instance=v["uuid"]
+                )
+            )
+
+    return servers
+
+
+def valide_instance(instance, values):
+    """Validate snapset_instance data structure"""
+
+    if not isinstance(values, dict):
+        raise ansible_exc.ArgumentTypeError(
+            "SnapSet instances must be a dict {instance} is type: {type}".format(
+                instance=instance, type=type(instance)
+            )
+        )
+
+    if values.keys() - INSTANCE_ALLOWED_KEYS:
+        raise ansible_exc.AnsibleValidationError(
+            "SnapSet instance {instance} has invalid keys {keys}".format(
+                instance=instance, keys=values.keys() - INSTANCE_ALLOWED_KEYS
+            )
+        )
+
+    if INSTANCE_REQUIRED_KEYS - values.keys():
+        raise ansible_exc.AnsibleValidationError(
+            "SnapSet instance {instance} is missing required keys {keys}".format(
+                instance=instance, keys=INSTANCE_REQUIRED_KEYS - values.keys()
+            )
+        )
+
+    for key in INSTANCE_REQUIRED_KEYS:
+        if not isinstance(values[key], str):
+            raise ansible_exc.AnsibleValidationError(
+                "SnapSet instance {instance} invalid value for {key} must be a string".format(
+                    instance=instance, key=key
+                )
+            )
+
+
+def validate_snapset_data(data):
+    """Validates the snapset_data parameter data structure and content.
+
+    :param data: The input SnapSet data structure.
+    :raises: AnsibleValidationError - if the input is invalid
+    """
+    if not isinstance(data, dict):
+        raise ansible_exc.ArgumentTypeError("snapset_data must be a dict")
+
+    if "instances" not in data:
+        raise ansible_exc.AnsibleValidationError(
+            "snapset_data must contain 'instances'"
+        )
+
+    for instance, values in data["instances"].items():
+        valide_instance(instance, values)
+
+
+def run_module():
+    argument_spec = yaml.safe_load(DOCUMENTATION)["options"]
+    module = AnsibleModule(argument_spec, supports_check_mode=False)
+
+    if not HAS_OPENSTACK:
+        module.fail_json(
+            msg='Could not import "openstack" library. \
+              openstack is required on PYTHONPATH to run this module',
+            python=sys.executable,
+            python_version=sys.version,
+            python_system_path=sys.path,
+        )
+
+    result = dict(
+        success=False,
+        changed=False,
+        snapset=dict(),
+        error="",
+    )
+
+    cloud = module.params["cloud"]
+    data = module.params["snapset_data"]
+
+    try:
+        validate_snapset_data(data)
+
+        conn = openstack.connect(cloud)
+        servers = get_servers(conn, data["instances"])
+        validate_servers_state(servers)
+        snapset = create_snapset(conn, data["instances"])
+
+        result["snapset"] = snapset
+        result["success"] = True
+        result["changed"] = True
+
+        module.exit_json(**result)
+    except Exception as err:
+        result["error"] = str(err)
+        result["msg"] = "Failed to create snapshots from instances, {err}".format(
+            err=err
+        )
+        module.fail_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/hot_snapset/tasks/main.yml
+++ b/roles/hot_snapset/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert config is defined
+  ansible.builtin.assert:
+    that:
+      - snapset_data is defined
+      - snapset_data | type_debug == 'dict'
+      - snapset_data | length > 0
+      - snapset_data.instances is defined
+      - snapset_data.instances | type_debug == 'dict'
+      - snapset_data.instances | length > 0
+      - controller_ansible_host is defined
+      - controller_ansible_host | length > 0
+
+- name: Add controller-0 to the Ansible inventory
+  ansible.builtin.add_host: "{{ controller_ansible_host }}"
+
+- name: Shutdown the controller node
+  delegate_to: "{{ controller_ansible_host.name }}"
+  become: true
+  community.general.shutdown:
+    msg: "Shutdown for Hotstack SnapSet"
+
+- name: Wait for servers in SnapSet data to be in SHUTOFF state
+  register: __instance_info
+  openstack.cloud.server_info:
+    cloud: "{{ os_cloud }}"
+    name: "{{ __instance.value.uuid }}"
+  loop: "{{ snapset_data.instances | dict2items }}"
+  loop_control:
+    loop_var: __instance
+  until: (__instance_info.servers[0].status == 'SHUTOFF')
+  retries: 25
+  delay: 10
+
+- name: Create Hotstack SnapSet
+  register: __snapset_result
+  hotstack_snapset:
+    cloud: "{{ os_cloud }}"
+    snapset_data: "{{ snapset_data }}"
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: "{{ __snapset_result }}"

--- a/roles/ocp_agent_installer/defaults/main.yml
+++ b/roles/ocp_agent_installer/defaults/main.yml
@@ -14,26 +14,31 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+ocp_agent_installer_prepare_for_snapshot: false
+ocp_agent_installer_revive_snapshot: false
+
+
 # Can be one of ['pxe', 'iso']
-bootstrap_assets: pxe
-add_ingress_cert_to_ca_trust: true
+ocp_agent_installer_bootstrap_assets: pxe
+ocp_agent_installer_add_ingress_cert_to_ca_trust: true
 
 openshift_version: stable-4.18
-client_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{ openshift_version }}/openshift-client-linux.tar.gz
-installer_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{ openshift_version }}/openshift-install-linux.tar.gz
+ocp_agent_installer_mirror_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
+ocp_agent_installer_client_url: "{{ ocp_agent_installer_mirror_url }}/{{ openshift_version }}/openshift-client-linux.tar.gz"
+ocp_agent_installer_installer_url: "{{ ocp_agent_installer_mirror_url }}/{{ openshift_version }}/openshift-install-linux.tar.gz"
 
 base_dir: /home/zuul
 bin_dir: "{{ base_dir }}/bin"
-kube_config_dir: "{{ base_dir }}/.kube"
-cluster_dir: "{{ base_dir }}/ocp-cluster"
-manifests_dir: "{{ cluster_dir }}/openshift"
-agent_installer_dir: "{{ base_dir }}/agent-installer"
-cluster_custom_config_dir: "{{ base_dir }}/cluster-custom-config/"
-butane_dir: "{{ cluster_custom_config_dir }}/butane"
-machine_configs_dir: "{{ cluster_custom_config_dir }}/machine-configs"
-config_assets_dir: "{{ cluster_custom_config_dir }}/config-assets"
+ocp_agent_installer_kube_config_dir: "{{ base_dir }}/.kube"
+ocp_agent_installer_cluster_dir: "{{ base_dir }}/ocp-cluster"
+ocp_agent_installer_manifests_dir: "{{ ocp_agent_installer_cluster_dir }}/openshift"
+ocp_agent_installer_agent_installer_dir: "{{ base_dir }}/agent-installer"
+ocp_agent_installer_cluster_custom_config_dir: "{{ base_dir }}/cluster-custom-config/"
+ocp_agent_installer_butane_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/butane"
+ocp_agent_installer_machine_configs_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/machine-configs"
+ocp_agent_installer_config_assets_dir: "{{ ocp_agent_installer_cluster_custom_config_dir }}/config-assets"
 
-boot_artifacts_dir: /var/www/html/boot-artifacts
+ocp_agent_installer_boot_artifacts_dir: /var/www/html/boot-artifacts
 
 install_config:
 agent_config:

--- a/roles/ocp_agent_installer/tasks/_install.yml
+++ b/roles/ocp_agent_installer/tasks/_install.yml
@@ -1,0 +1,155 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Assert config is defined
+  ansible.builtin.assert:
+    that:
+      - install_config is defined
+      - install_config | length > 0
+      - agent_config is defined
+      - agent_config | length > 0
+
+- name: Ensure directory exists
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - "{{ bin_dir }}"
+    - "{{ ocp_agent_installer_kube_config_dir }}"
+    - "{{ ocp_agent_installer_cluster_dir }}"
+    - "{{ ocp_agent_installer_manifests_dir }}"
+    - "{{ ocp_agent_installer_agent_installer_dir }}"
+    - "{{ ocp_agent_installer_cluster_custom_config_dir }}"
+    - "{{ ocp_agent_installer_butane_dir }}"
+    - "{{ ocp_agent_installer_machine_configs_dir }}"
+    - "{{ ocp_agent_installer_config_assets_dir }}"
+
+- name: Install package requirements for agent installer
+  become: true
+  ansible.builtin.dnf:
+    name:
+      - nmstate
+      - butane
+    state: present
+
+- name: Run tasks/install_client.yml
+  ansible.builtin.include_tasks: install_client.yml
+
+- name: Run tasks/install_installer.yml
+  ansible.builtin.include_tasks: install_installer.yml
+
+- name: Write OCP install-config.yaml
+  ansible.builtin.copy:
+    content: >-
+      {{
+        install_config | to_nice_yaml(indent=2)
+      }}
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir,
+          'install-config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Replace pull secret in install-config.yaml
+  no_log: true
+  ansible.builtin.replace:
+    path: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir, 'install-config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    regexp: '^pullSecret: _replaced_$'
+    replace: |
+      pullSecret: '{{ pull_secret | b64decode }}'
+
+- name: Write OCP agent-config.yaml
+  ansible.builtin.copy:
+    content: >-
+      {{
+        agent_config | to_nice_yaml(indent=2)
+      }}
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir,
+          'agent-config.yaml'
+        ] | ansible.builtin.path_join
+      }}
+    mode: '0644'
+
+- name: Include tasks to generate machine configs
+  ansible.builtin.include_tasks: machine_configs.yml
+
+- name: Include tasks to generate config assets
+  ansible.builtin.include_tasks: config_assets.yml
+
+- name: Copy machine_configs to manifests dir
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ocp_agent_installer_machine_configs_dir }}/"
+    dest: "{{ ocp_agent_installer_manifests_dir }}/"
+
+- name: Copy config assets to manifests dir
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ ocp_agent_installer_config_assets_dir }}/"
+    dest: "{{ ocp_agent_installer_manifests_dir }}/"
+
+- name: Run tasks/pxe_assets.yml
+  when: ocp_agent_installer_bootstrap_assets == 'pxe'
+  ansible.builtin.include_tasks: pxe_assets.yml
+
+- name: Run tasks/iso_assets.yml
+  when: ocp_agent_installer_bootstrap_assets == 'iso'
+  ansible.builtin.include_tasks: iso_assets.yml
+
+- name: Copy auth/kubeconfig to ~/.kube/config
+  ansible.builtin.copy:
+    remote_src: true
+    src: >-
+      {{
+        [
+          ocp_agent_installer_cluster_dir,
+          'auth',
+          'kubeconfig'
+        ] | ansible.builtin.path_join
+      }}
+    dest: >-
+      {{
+        [
+          ocp_agent_installer_kube_config_dir,
+          'config'
+        ] | ansible.builtin.path_join
+      }}
+
+- name: Wait for bootstrap-complete
+  ansible.builtin.command:
+    cmd: >
+      {{ bin_dir }}/openshift-install --dir {{ ocp_agent_installer_cluster_dir }} agent wait-for bootstrap-complete --log-level=info
+
+- name: Wait for install-complete
+  ansible.builtin.command:
+    cmd: >
+      {{ bin_dir }}/openshift-install --dir {{ ocp_agent_installer_cluster_dir }} agent wait-for install-complete
+
+- name: Add ingress certificate to CA trust
+  when: ocp_agent_installer_add_ingress_cert_to_ca_trust | bool
+  ansible.builtin.include_tasks: ingress_cert.yml

--- a/roles/ocp_agent_installer/tasks/config_assets.yml
+++ b/roles/ocp_agent_installer/tasks/config_assets.yml
@@ -21,7 +21,7 @@
     dest: >-
       {{
         [
-          config_assets_dir,
+          ocp_agent_installer_config_assets_dir,
           'ovn_k8s_config.yaml'
         ] | ansible.builtin.path_join
       }}
@@ -33,7 +33,7 @@
     dest: >-
       {{
         [
-          config_assets_dir,
+          ocp_agent_installer_config_assets_dir,
           '95-etcd_config.yaml'
         ] | ansible.builtin.path_join
       }}
@@ -45,7 +45,7 @@
     dest: >-
       {{
         [
-          config_assets_dir,
+          ocp_agent_installer_config_assets_dir,
           '95-image-content-source-policy.yaml'
         ] | ansible.builtin.path_join
       }}
@@ -72,7 +72,7 @@
         dest: >-
           {{
             [
-              config_assets_dir,
+              ocp_agent_installer_config_assets_dir,
               '93-additional-ca-config-map.yaml'
             ] | ansible.builtin.path_join
           }}
@@ -83,7 +83,7 @@
         dest: >-
           {{
             [
-              config_assets_dir,
+              ocp_agent_installer_config_assets_dir,
               '94-additional-ca-config-image.yaml'
             ] | ansible.builtin.path_join
           }}

--- a/roles/ocp_agent_installer/tasks/install_client.yml
+++ b/roles/ocp_agent_installer/tasks/install_client.yml
@@ -16,11 +16,11 @@
 
 - name: Download the client
   ansible.builtin.get_url:
-    url: "{{ client_url }}"
+    url: "{{ ocp_agent_installer_client_url }}"
     dest: >-
       {{
         [
-          agent_installer_dir,
+          ocp_agent_installer_agent_installer_dir,
           'openshift-client-linux.tar.gz'
         ] | ansible.builtin.path_join
       }}
@@ -31,7 +31,7 @@
     src: >-
       {{
         [
-          agent_installer_dir,
+          ocp_agent_installer_agent_installer_dir,
           'openshift-client-linux.tar.gz'
         ] | ansible.builtin.path_join
       }}

--- a/roles/ocp_agent_installer/tasks/install_installer.yml
+++ b/roles/ocp_agent_installer/tasks/install_installer.yml
@@ -16,11 +16,11 @@
 
 - name: Download the installer
   ansible.builtin.get_url:
-    url: "{{ installer_url }}"
+    url: "{{ ocp_agent_installer_installer_url }}"
     dest: >-
       {{
         [
-          agent_installer_dir,
+          ocp_agent_installer_agent_installer_dir,
           'openshift-install-linux.tar.gz'
         ] | ansible.builtin.path_join
       }}
@@ -31,7 +31,7 @@
     src: >-
       {{
         [
-          agent_installer_dir,
+          ocp_agent_installer_agent_installer_dir,
           'openshift-install-linux.tar.gz'
         ] | ansible.builtin.path_join
       }}

--- a/roles/ocp_agent_installer/tasks/machine_configs.yml
+++ b/roles/ocp_agent_installer/tasks/machine_configs.yml
@@ -22,13 +22,13 @@
         role: "{{ item }}"
       ansible.builtin.template:
         src: disable-netifnames.bu.j2
-        dest: "{{ butane_dir }}/90-{{ item }}-disable-netifnames.bu"
+        dest: "{{ ocp_agent_installer_butane_dir }}/90-{{ item }}-disable-netifnames.bu"
       loop: "{{ net_ifnames_roles }}"
     - name: Generate MachineConfig for iscsi
       ansible.builtin.command:
         cmd: >-
-          butane {{ butane_dir }}/90-{{ item }}-disable-netifnames.bu
-          -o {{ machine_configs_dir }}/90-{{ item }}-disable-netifnames.yaml
+          butane {{ ocp_agent_installer_butane_dir }}/90-{{ item }}-disable-netifnames.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/90-{{ item }}-disable-netifnames.yaml
       loop: "{{ net_ifnames_roles }}"
 
 - name: Enable iscsi
@@ -39,14 +39,14 @@
         role: "{{ item }}"
       ansible.builtin.template:
         src: enable-iscsi.bu.j2
-        dest: "{{ butane_dir }}/90-{{ item }}-enable-iscsi.bu"
+        dest: "{{ ocp_agent_installer_butane_dir }}/90-{{ item }}-enable-iscsi.bu"
       loop: "{{ iscsi_roles }}"
 
     - name: Generate MachineConfig for iscsi
       ansible.builtin.command:
         cmd: >-
-          butane {{ butane_dir }}/90-{{ item }}-enable-iscsi.bu
-          -o {{ machine_configs_dir }}/90-{{ item }}-enable-iscsi.yaml
+          butane {{ ocp_agent_installer_butane_dir }}/90-{{ item }}-enable-iscsi.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/90-{{ item }}-enable-iscsi.yaml
       loop: "{{ iscsi_roles }}"
 
 - name: Enable Multipath
@@ -57,14 +57,14 @@
         role: "{{ item }}"
       ansible.builtin.template:
         src: enable-multipath.bu.j2
-        dest: "{{ butane_dir }}/91-{{ item }}-enable-multipath.bu"
+        dest: "{{ ocp_agent_installer_butane_dir }}/91-{{ item }}-enable-multipath.bu"
       loop: "{{ multipath_roles }}"
 
     - name: Generate MachineConfig for multipath
       ansible.builtin.command:
         cmd: >-
-          butane {{ butane_dir }}/91-{{ item }}-enable-multipath.bu
-          -o {{ machine_configs_dir }}/91-{{ item }}-enable-multipath.yaml
+          butane {{ ocp_agent_installer_butane_dir }}/91-{{ item }}-enable-multipath.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/91-{{ item }}-enable-multipath.yaml
       loop: "{{ multipath_roles }}"
 
 - name: LVM cinder-volumes
@@ -75,12 +75,12 @@
         role: "{{ item }}"
       ansible.builtin.template:
         src: lv-cinder-volumes.bu.j2
-        dest: "{{ butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu"
+        dest: "{{ ocp_agent_installer_butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu"
       loop: "{{ cinder_volume_roles }}"
 
     - name: Generate MachineConfig for multipath
       ansible.builtin.command:
         cmd: >-
-          butane {{ butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu
-          -o {{ machine_configs_dir }}/92-{{ item }}-lv-cinder-volumes.yaml
+          butane {{ ocp_agent_installer_butane_dir }}/92-{{ item }}-lv-cinder-volumes.bu
+          -o {{ ocp_agent_installer_machine_configs_dir }}/92-{{ item }}-lv-cinder-volumes.yaml
       loop: "{{ cinder_volume_roles }}"

--- a/roles/ocp_agent_installer/tasks/main.yml
+++ b/roles/ocp_agent_installer/tasks/main.yml
@@ -17,141 +17,48 @@
 - name: Assert config is defined
   ansible.builtin.assert:
     that:
-      - install_config is defined
-      - install_config | length > 0
-      - agent_config is defined
-      - agent_config | length > 0
       - pull_secret is defined
       - pull_secret | length > 0
 
-- name: Ensure directory exists
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: '0755'
-  loop:
-    - "{{ bin_dir }}"
-    - "{{ kube_config_dir }}"
-    - "{{ cluster_dir }}"
-    - "{{ manifests_dir }}"
-    - "{{ agent_installer_dir }}"
-    - "{{ cluster_custom_config_dir }}"
-    - "{{ butane_dir }}"
-    - "{{ machine_configs_dir }}"
-    - "{{ config_assets_dir }}"
+- name: Install using agent installer
+  when: not ocp_agent_installer_revive_snapshot | bool
+  ansible.builtin.include_tasks: _install.yml
 
-- name: Install package requirements for agent installer
-  become: true
-  ansible.builtin.dnf:
-    name:
-      - nmstate
-      - butane
-    state: present
+# NOTE(hjensas): The bootstrap certificate is used to bootstrap the cluster
+# and is valid for 24 hours. After 24 hours, the certificate is rotated and
+# the new certificate is valid for 30 days. The snapshot is taken after the
+# bootstrap certificate has rotated, so that no workarounds are needed to get
+# the cluster to a stable state. Snapshots will work without workarounds for
+# the next 30 days.
+- name: Wait for 25 hours to prepare for snapshot
+  when: ocp_agent_installer_prepare_for_snapshot | bool
+  ansible.builtin.pause:
+    minutes: "{{ 25 * 60 }}"
 
-- name: Run tasks/install_client.yml
-  ansible.builtin.include_tasks: install_client.yml
+- name: Prepare for Snapshot - and shutdown
+  when: ocp_agent_installer_prepare_for_snapshot | bool
+  ansible.builtin.command: >-
+    hotstack-snapset
+      --wait-cluster-stable 60s
+      --cordon
+      --shutdown
 
-- name: Run tasks/install_installer.yml
-  ansible.builtin.include_tasks: install_installer.yml
-
-- name: Write OCP install-config.yaml
-  ansible.builtin.copy:
-    content: >-
-      {{
-        install_config | to_nice_yaml(indent=2)
-      }}
-    dest: >-
-      {{
-        [
-          cluster_dir,
-          'install-config.yaml'
-        ] | ansible.builtin.path_join
-      }}
-    mode: '0644'
-
-- name: Replace pull secret in install-config.yaml
-  no_log: true
-  ansible.builtin.replace:
-    path: >-
-      {{
-        [
-          cluster_dir, 'install-config.yaml'
-        ] | ansible.builtin.path_join
-      }}
-    regexp: '^pullSecret: _replaced_$'
-    replace: |
-      pullSecret: '{{ pull_secret | b64decode }}'
-
-- name: Write OCP agent-config.yaml
-  ansible.builtin.copy:
-    content: >-
-      {{
-        agent_config | to_nice_yaml(indent=2)
-      }}
-    dest: >-
-      {{
-        [
-          cluster_dir,
-          'agent-config.yaml'
-        ] | ansible.builtin.path_join
-      }}
-    mode: '0644'
-
-- name: Include tasks to generate machine configs
-  ansible.builtin.include_tasks: machine_configs.yml
-
-- name: Include tasks to generate config assets
-  ansible.builtin.include_tasks: config_assets.yml
-
-- name: Copy machine_configs to manifests dir
-  ansible.builtin.copy:
-    remote_src: true
-    src: "{{ machine_configs_dir }}/"
-    dest: "{{ manifests_dir }}/"
-
-- name: Copy config assets to manifests dir
-  ansible.builtin.copy:
-    remote_src: true
-    src: "{{ config_assets_dir }}/"
-    dest: "{{ manifests_dir }}/"
-
-- name: Run tasks/pxe_assets.yml
-  when: bootstrap_assets == 'pxe'
-  ansible.builtin.include_tasks: pxe_assets.yml
-
-- name: Run tasks/iso_assets.yml
-  when: bootstrap_assets == 'iso'
-  ansible.builtin.include_tasks: iso_assets.yml
-
-- name: Copy auth/kubeconfig to ~/.kube/config
-  ansible.builtin.copy:
-    remote_src: true
-    src: >-
-      {{
-        [
-          cluster_dir,
-          'auth',
-          'kubeconfig'
-        ] | ansible.builtin.path_join
-      }}
-    dest: >-
-      {{
-        [
-          kube_config_dir,
-          'config'
-        ] | ansible.builtin.path_join
-      }}
-
-- name: Wait for bootstrap-complete
-  ansible.builtin.command:
-    cmd: >
-      {{ bin_dir }}/openshift-install --dir {{ cluster_dir }} agent wait-for bootstrap-complete --log-level=info
-
-- name: Wait for install-complete
-  ansible.builtin.command:
-    cmd: >
-      {{ bin_dir }}/openshift-install --dir {{ cluster_dir }} agent wait-for install-complete
-
-- name: Add ingress certificate to CA trust
-  when: add_ingress_cert_to_ca_trust | bool
-  ansible.builtin.include_tasks: ingress_cert.yml
+# NOTE(hjensas): Use the hotstack-snapset utility to wait for cluster
+# stability for 5 seconds, uncordon the nodes then wait for cluster stability,
+# wait for route.openshift.io API version to be available.
+#
+# The wait for cluster stability is repeated with a short stable state
+# requirement. This is faster than waiting one time for a longer time because
+# the timer is reset every time cluster stability is lost.
+#
+# Even if the cluster is stable, the route.openshift.io API version may not be
+# available, wait for it to appear in oc api-versions output.
+- name: Wait for cluster, uncordon, wait for cluster, wait for route API version ...
+  when: ocp_agent_installer_revive_snapshot | bool
+  ansible.builtin.command: >-
+    hotstack-snapset
+      --wait-cluster-stable 5s
+      --uncordon
+      --wait-cluster-stable 60s
+      --wait-cluster-stable 60s
+      --wait-for-api-versions-route

--- a/roles/ocp_agent_installer/tasks/pxe_assets.yml
+++ b/roles/ocp_agent_installer/tasks/pxe_assets.yml
@@ -17,19 +17,19 @@
 - name: Create the boot-artifacts directory
   become: true
   ansible.builtin.file:
-    path: "{{ boot_artifacts_dir }}"
+    path: "{{ ocp_agent_installer_boot_artifacts_dir }}"
     state: directory
     mode: '0755'
 
 - name: Create PXE assets
   ansible.builtin.command:
-    chdir: "{{ cluster_dir }}"
+    chdir: "{{ ocp_agent_installer_cluster_dir }}"
     cmd: >
       {{ bin_dir }}/openshift-install agent create pxe-files
 
 - name: Set serial console in ipxe
   ansible.builtin.lineinfile:
-    path: "{{ cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
+    path: "{{ ocp_agent_installer_cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
     backrefs: true
     regexp: "^(kernel.*)$"
     line: '\1 console=ttyS0'
@@ -37,24 +37,24 @@
 - name: Disable net.ifnames
   when: disable_net_ifnames | bool
   ansible.builtin.lineinfile:
-    path: "{{ cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
+    path: "{{ ocp_agent_installer_cluster_dir }}/boot-artifacts/agent.x86_64.ipxe"
     backrefs: true
     regexp: "^(kernel.*)$"
     line: '\1 net.ifnames=0'
 
-- name: Copy boot-artifacts to the web server - (boot_artifacts_dir)
+- name: Copy boot-artifacts to the web server - (ocp_agent_installer_boot_artifacts_dir)
   become: true
   ansible.builtin.copy:
     remote_src: true
     src: >-
       {{
         [
-          cluster_dir,
+          ocp_agent_installer_cluster_dir,
           'boot-artifacts',
           item
         ] | ansible.builtin.path_join
       }}
-    dest: "{{ boot_artifacts_dir }}"
+    dest: "{{ ocp_agent_installer_boot_artifacts_dir }}"
     owner: root
     group: root
     mode: '0644'

--- a/scenarios/3-nodes/heat_template.yaml
+++ b/scenarios/3-nodes/heat_template.yaml
@@ -336,6 +336,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
       fixed_ips:
         - ip_address: 192.168.32.254
 
@@ -381,6 +382,7 @@ resources:
     properties:
       network: {get_resource: machine-net}
       port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
       fixed_ips:
         - ip_address: 192.168.32.10
       value_specs: {get_attr: [extra-dhcp-opts-value, value]}

--- a/scenarios/multi-nodeset/heat_template.yaml
+++ b/scenarios/multi-nodeset/heat_template.yaml
@@ -344,6 +344,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
       fixed_ips:
         - ip_address: 192.168.32.254
 
@@ -389,6 +390,7 @@ resources:
     properties:
       network: {get_resource: machine-net}
       port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
       fixed_ips:
         - ip_address: 192.168.32.10
       value_specs: {get_attr: [extra-dhcp-opts-value, value]}

--- a/scenarios/multi-ns/heat_template.yaml
+++ b/scenarios/multi-ns/heat_template.yaml
@@ -480,6 +480,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
       fixed_ips:
         - ip_address: 192.168.32.254
 
@@ -525,6 +526,7 @@ resources:
     properties:
       network: {get_resource: machine-net}
       port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
       fixed_ips:
         - ip_address: 192.168.32.10
       value_specs: {get_attr: [extra-dhcp-opts-value, value]}

--- a/scenarios/snapshot-sno/bootstrap_vars.yml
+++ b/scenarios/snapshot-sno/bootstrap_vars.yml
@@ -1,0 +1,53 @@
+---
+ocp_agent_installer_prepare_for_snapshot: true
+ocp_agent_installer_min_stable_period: 3m
+
+os_cloud: default
+os_floating_network: public
+os_router_external_network: public
+
+controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
+
+scenario: snapshot-sno
+scenario_dir: scenarios
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+
+openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
+openstack_operator_channel: alpha
+openstack_operator_starting_csv: null
+
+openshift_version: stable-4.18
+
+ntp_servers: []
+dns_servers:
+  - 8.8.8.8
+  - 8.8.4.4
+
+pull_secret_file: ~/pull-secret.txt
+
+ovn_k8s_gateway_config_host_routing: true
+enable_iscsi: true
+enable_multipath: true
+
+cinder_volume_pvs:
+  - /dev/vdc
+  - /dev/vdd
+  - /dev/vde
+
+stack_name: "hs-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  # On misconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  ocp_master_params:
+    image: ipxe-boot-usb
+    flavor: hotstack.xxlarge

--- a/scenarios/snapshot-sno/heat_template.yaml
+++ b/scenarios/snapshot-sno/heat_template.yaml
@@ -1,0 +1,385 @@
+---
+heat_template_version: rocky
+
+description: >
+  Heat template to set up infra for snapshot. Hotstack controller + OCP SNO node
+
+parameters:
+  dns_servers:
+    type: comma_delimited_list
+    default:
+      - 8.8.8.8
+      - 8.8.4.4
+  ntp_servers:
+    type: comma_delimited_list
+    default: []
+  controller_ssh_pub_key:
+    type: string
+  dataplane_ssh_pub_key:
+    type: string
+  router_external_network:
+    type: string
+    default: public
+  floating_ip_network:
+    type: string
+    default: public
+  net_value_specs:
+    type: json
+    default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  ocp_master_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  compute_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networker_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironic_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+
+
+resources:
+  #
+  # Networks
+  #
+  machine-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  #
+  # Subnets
+  #
+  machine-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: machine-net}
+      ip_version: 4
+      cidr: 192.168.32.0/24
+      enable_dhcp: true
+      dns_nameservers:
+        - 192.168.32.254
+
+  #
+  # Routers
+  #
+  router:
+    type: OS::Neutron::Router
+    properties:
+      admin_state_up: true
+      external_gateway_info:
+        network: {get_param: router_external_network}
+        # enable_snat: true
+
+  machine-net-router-interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: router}
+      subnet: {get_resource: machine-subnet}
+
+  #
+  # Instances
+  #
+  controller_users:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        users:
+          - default
+          - name: zuul
+            gecos: "Zuul user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+
+  controller-write-files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+          - path: /etc/dnsmasq.conf
+            content: |
+              # dnsmasq service config
+              # Include all files in /etc/dnsmasq.d except RPM backup files
+              conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig
+              no-resolv
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/forwarders.conf
+            content:
+              str_replace:
+                template: |
+                  # DNS forwarders records
+                  server=$dns1
+                  server=$dns2
+                params:
+                  $dns1: {get_param: [dns_servers, 0]}
+                  $dns2: {get_param: [dns_servers, 1]}
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/host_records.conf
+            content:
+              str_replace:
+                template: |
+                  # Host records
+                  host-record=controller-0.openstack.lab,$controller0
+                  host-record=api.sno.openstack.lab,$master0
+                  host-record=api-int.sno.openstack.lab,$master0
+                  host-record=master-0.sno.openstack.lab,$master0
+                params:
+                  $controller0: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+                  $master0: {get_attr: [master0-machine-port, fixed_ips, 0, ip_address]}
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/wildcard_records.conf
+            content:
+              str_replace:
+                template: |
+                  # Wildcard records
+                  address=/apps.sno.openstack.lab/$addr
+                params:
+                  $addr: {get_attr: [master0-machine-port, fixed_ips, 0, ip_address]}
+            owner: root:dnsmasq
+          - path: /etc/resolv.conf
+            content: |
+              nameserver: 127.0.0.1
+            owner: root:root
+          - path: /etc/NetworkManager/conf.d/98-rc-manager.conf
+            content: |
+              [main]
+              rc-manager=unmanaged
+            owner: root:root
+
+  controller-runcmd:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        runcmd:
+          - ['systemctl', 'enable', 'dnsmasq.service']
+          - ['systemctl', 'start', 'dnsmasq.service']
+          - ['setenforce', 'permissive']
+          - ['sed', '-i', 's/Listen 80/Listen 8081/g', '/etc/httpd/conf/httpd.conf']
+          - ['systemctl', 'enable', 'httpd.service']
+          - ['systemctl', 'start', 'httpd.service']
+
+  controller-init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: {get_resource: controller_users}
+        - config: {get_resource: controller-write-files}
+        - config: {get_resource: controller-runcmd}
+
+  controller-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
+      fixed_ips:
+        - ip_address: 192.168.32.254
+
+  controller-floating-ip:
+    depends_on: machine-net-router-interface
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: floating_ip_network}
+      port_id: {get_resource: controller-machine-port}
+
+  controller:
+    type: OS::Nova::Server
+    properties:
+      image: {get_param: [controller_params, image]}
+      flavor: {get_param: [controller_params, flavor]}
+      networks:
+        - port: {get_resource: controller-machine-port}
+      user_data_format: RAW
+      user_data: {get_resource: controller-init}
+
+  # OCP Masters
+
+  # DHCP Opts value
+  extra-dhcp-opts-value:
+    type: OS::Heat::Value
+    properties:
+      type: json
+      value:
+        extra_dhcp_opts:
+          - opt_name: "60"
+            opt_value: "HTTPClient"
+            ip_version: 4
+          - opt_name: "67"
+            opt_value:
+              str_replace:
+                template: http://$server_address:8081/boot-artifacts/agent.x86_64.ipxe
+                params:
+                  $server_address: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+
+
+  master0-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
+      fixed_ips:
+        - ip_address: 192.168.32.10
+      value_specs: {get_attr: [extra-dhcp-opts-value, value]}
+
+  master0-lvms-vol0:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  master0-cinder-vol0:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  master0-cinder-vol1:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  master0-cinder-vol2:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  master0:
+    type: OS::Nova::Server
+    properties:
+      image: {get_param: [ocp_master_params, image]}
+      flavor: {get_param: [ocp_master_params, flavor]}
+      block_device_mapping_v2:
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: master0-lvms-vol0}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: master0-cinder-vol0}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: master0-cinder-vol1}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: master0-cinder-vol2}
+      networks:
+        - port: {get_resource: master0-machine-port}
+
+outputs:
+  controller_floating_ip:
+    description: Controller Floating IP
+    value: {get_attr: [controller-floating-ip, floating_ip_address]}
+
+  controller_ansible_host:
+    description: >
+      Controller ansible host, this struct can be passed to the ansible.builtin.add_host module
+    value:
+      name: controller-0
+      ansible_ssh_user: zuul
+      ansible_host: {get_attr: [controller-floating-ip, floating_ip_address]}
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+      groups: controllers
+
+  ocp_install_config:
+    description: OCP install-config.yaml
+    value:
+      apiVersion: v1
+      baseDomain: openstack.lab
+      controlPlane:
+        architecture: amd64
+        hyperthreading: Disabled
+        name: master
+        replicas: 1
+      compute:
+        - architecture: amd64
+          hyperthreading: Disabled
+          name: worker
+          replicas: 0
+      metadata:
+        name: sno
+      networking:
+        clusterNetwork:
+          - cidr: 10.128.0.0/16
+            hostPrefix: 23
+        machineNetwork:
+          - cidr: {get_attr: [machine-subnet, cidr]}
+        serviceNetwork:
+          - 172.30.0.0/16
+        networkType: OVNKubernetes
+      platform:
+        none: {}
+      pullSecret: _replaced_
+      sshKey: {get_param: dataplane_ssh_pub_key}
+
+  ocp_agent_config:
+    description: OCP agent-config.yaml
+    value:
+      apiVersion: v1beta1
+      kind: AgentConfig
+      metadata:
+        name: sno
+      rendezvousIP: {get_attr: [master0-machine-port, fixed_ips, 0, ip_address]}
+      additionalNTPSources: {get_param: ntp_servers}
+      bootArtifactsBaseURL:
+        str_replace:
+          template: http://$server_address:8081/boot-artifacts
+          params:
+            $server_address: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+      hosts:
+        - hostname: master-0
+          role: master
+          interfaces:
+            - name: eth0
+              macAddress: {get_attr: [master0-machine-port, mac_address]}
+          networkConfig:
+            interfaces:
+              - name: eth0
+                type: ethernet
+                state: up
+                mac-address: {get_attr: [master0-machine-port, mac_address]}
+                ipv4:
+                  enabled: true
+                  dhcp: true
+                ipv6:
+                  enabled: false
+
+  snapset_data:
+    description: >
+      Information about instance UUID's and volume UUIDs that need to be in the Snapshot collection.
+    value:
+      instances:
+        controller:
+          uuid: {get_resource: controller}
+          role: controller
+          mac_address: {get_attr: [controller-machine-port, mac_address]}
+        master0:
+          uuid: {get_resource: master0}
+          role: ocp_master
+          mac_address: {get_attr: [master0-machine-port, mac_address]}

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -340,6 +340,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
       fixed_ips:
         - ip_address: 192.168.32.254
 
@@ -385,6 +386,7 @@ resources:
     properties:
       network: {get_resource: machine-net}
       port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
       fixed_ips:
         - ip_address: 192.168.32.10
       value_specs: {get_attr: [extra-dhcp-opts-value, value]}

--- a/scenarios/sno-bmh-tests/heat_template.yaml
+++ b/scenarios/sno-bmh-tests/heat_template.yaml
@@ -470,6 +470,7 @@ resources:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
       fixed_ips:
         - ip_address: 192.168.32.254
 
@@ -515,6 +516,7 @@ resources:
     properties:
       network: {get_resource: machine-net}
       port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
       fixed_ips:
         - ip_address: 192.168.32.10
       value_specs: {get_attr: [extra-dhcp-opts-value, value]}


### PR DESCRIPTION
- Add `hotstack-snapset` utility for cluster snapshot preparation and revival.
 - Support waiting for cluster stability, cordoning/uncordoning nodes, and shutdown
 - Allow multiple invocations of any command for complex sequential workflows e.g. revival mode with progressive stability checks and uncordoning.
- Add snapshot preparation mode to OCP agent installer (25-hour wait + shutdown) to allow the initial 24-hour bootstrap certificate rotation to complete before creating a snapshot.
- Add hot_snapset Ansible role for snapshot management operations.