### PR TITLE
fix templating in openstack-olm-update.j2

### DIFF
--- a/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
+++ b/roles/hotloop/templates/common/stages/openstack-olm-update.yaml.j2
@@ -19,6 +19,7 @@
     - >-
       {{
         openstack_operators_starting_csv is defined and
+        openstack_operators_starting_csv is not none and
         openstack_operators_starting_csv is version('v1.0.0', '>=') and
         openstack_operators_starting_csv is version('v1.0.7', '<')
       }}


### PR DESCRIPTION
Whe openstack_operators_starting_csv is defined as 'null' the 'version' compare failed. Add a check that starting_csv is not none.