### PR TITLE
Use a container for iPXE image job

### DIFF
--- a/zuul.d/nodeset.yaml
+++ b/zuul.d/nodeset.yaml
@@ -8,4 +8,4 @@
     name: hotstack-image
     nodes:
       - name: hotstack
-        label: cloud-centos-9-stream-tripleo-vexxhost
+        label: pod-centos-9-stream


### PR DESCRIPTION
Trying to switch to run the build and upload of iPXE image to use a container POD instead of a node.