### PR TITLE
refactor: separate TopoLVM dependencies

### DIFF
--- a/roles/hotloop/templates/common/stages/deps-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/deps-stages.yaml.j2
@@ -1,15 +1,4 @@
 ---
-- name: TopoLVM common
-  documentation: |
-    Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
-    cluster.
-
-    It uses LVMS (Logical Volume Manager Storage) to dynamically provision
-    local storage built from block devices on OCP nodes.
-
-    After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
-  manifest: "{{ role_path }}/files/common/manifests/deps/olm-topolvm.yaml"
-
 - name: Common OLM Dependencies
   documentation: |
     Install the OpenStack K8S dependencies. (Namespaces, OperatorGroup, and Subscription CRs.)

--- a/roles/hotloop/templates/common/stages/topolvm-deps-stages.yaml.j2
+++ b/roles/hotloop/templates/common/stages/topolvm-deps-stages.yaml.j2
@@ -1,0 +1,11 @@
+---
+- name: TopoLVM common
+  documentation: |
+    Install the TopoLVM Container Storage Interface (CSI) driver on the OCP
+    cluster.
+
+    It uses LVMS (Logical Volume Manager Storage) to dynamically provision
+    local storage built from block devices on OCP nodes.
+
+    After you have installed LVM Storage, you must create an LVMCluster custom resource (CR).
+  manifest: "{{ role_path }}/files/common/manifests/deps/olm-topolvm.yaml"

--- a/scenarios/3-nodes/automation-vars.yml
+++ b/scenarios/3-nodes/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/compact-4-bm/automation-vars.yml
+++ b/scenarios/compact-4-bm/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     documentation: |
       Installs essential dependencies and prerequisites for the OpenStack deployment.

--- a/scenarios/hci/automation-vars.yml
+++ b/scenarios/hci/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/multi-nodeset/automation-vars.yml
+++ b/scenarios/multi-nodeset/automation-vars.yml
@@ -16,6 +16,13 @@ stages:
                "common/stages/cinder-lvm-label-stages.yaml")
       }}
 
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/multi-ns/automation-vars.yml
+++ b/scenarios/multi-ns/automation-vars.yml
@@ -8,6 +8,14 @@ stages:
         lookup("ansible.builtin.template",
                "common/stages/metal-platform-provisioning.yaml.j2")
       }}
+
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/sno-2-bm-flat-vlan/automation-vars.yml
+++ b/scenarios/sno-2-bm-flat-vlan/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     documentation: |
       Install and configure base dependencies required for OpenStack deployment,

--- a/scenarios/sno-2-bm/automation-vars.yml
+++ b/scenarios/sno-2-bm/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/sno-bmh-tests/automation-vars.yml
+++ b/scenarios/sno-bmh-tests/automation-vars.yml
@@ -9,6 +9,13 @@ stages:
                "common/stages/metal-platform-provisioning.yaml.j2")
       }}
 
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/sno-nxsw/automation-vars.yml
+++ b/scenarios/sno-nxsw/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{

--- a/scenarios/uni01alpha/automation-vars.yml
+++ b/scenarios/uni01alpha/automation-vars.yml
@@ -1,5 +1,12 @@
 ---
 stages:
+  - name: TopoLVM Dependencies
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/topolvm-deps-stages.yaml.j2")
+      }}
+
   - name: Dependencies
     stages: >-
       {{


### PR DESCRIPTION
Extract TopoLVM installation from deps-stages.yaml.j2 into a new topolvm-deps-stages.yaml.j2 file to allow independent deployment of TopoLVM vs other OLM dependencies. Update all scenarios to include the new TopoLVM Dependencies stage.