### PR TITLE
feat(hotloop): Add delegation support

### DIFF
--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -227,6 +227,21 @@ stages:
       timeout: 180
 ```
 
+## Delegation Support
+
+The hotloop role supports delegation to remote hosts. When using
+`delegate_to`, the role automatically:
+
+1. Pre-fetches all required manifest files and kustomize directories
+   from the source host
+2. Templates Jinja2 manifests on the source host before transferring
+3. Uses the pre-fetched content during execution on the delegated host
+
+### Variables for Delegation
+
+* `source_host`: (string) The host to fetch files from when using
+  delegation. Defaults to `localhost`.
+
 ## Example playbook
 
 ```yaml
@@ -257,4 +272,5 @@ stages:
       delegate_to: controller-0
       vars:
         work_dir: "{{ scenario_dir }}/{{ scenario }}"
+        source_host: localhost  # Optional, defaults to localhost
 ```

--- a/roles/hotloop/defaults/main.yml
+++ b/roles/hotloop/defaults/main.yml
@@ -17,6 +17,8 @@
 wait_condition_retry_delay: 5
 wait_condition_retries: 50
 manifests_dir: /home/zuul/manifests
+source_host: localhost
+_hotloop_file_contents: {}
 automation:
   stages: []
 

--- a/roles/hotloop/tasks/collect_files.yml
+++ b/roles/hotloop/tasks/collect_files.yml
@@ -1,0 +1,248 @@
+---
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Initialize file collection variables
+  ansible.builtin.set_fact:
+    _hotloop_static_files: []
+    _hotloop_template_files: []
+    _hotloop_kustomize_dirs: []
+    _hotloop_file_contents: {}
+
+- name: Check for static manifest files in work_dir
+  when: item.manifest is defined
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.stat:
+    path: "{{ [work_dir, item.manifest] | ansible.builtin.path_join }}"
+  register: _work_dir_file_check
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Collect static manifest files
+  when: item.manifest is defined
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.set_fact:
+    _hotloop_static_files: >-
+      {{
+        _hotloop_static_files + [
+          {
+            'stage_name': item.name,
+            'file_path': _file_path,
+            'manifest_key': item.manifest
+          }
+        ]
+      }}
+  vars:
+    _work_dir_result: "{{ _work_dir_file_check.results[ansible_loop.index0] }}"
+    _file_path: >-
+      {{
+        _work_dir_result.stat.path if _work_dir_result.stat.exists
+        else lookup('ansible.builtin.first_found', [item.manifest])
+      }}
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+    extended: true
+
+- name: Check for template manifest files in work_dir
+  when: item.j2_manifest is defined
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.stat:
+    path: "{{ [work_dir, item.j2_manifest] | ansible.builtin.path_join }}"
+  register: _work_dir_template_check
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Collect template manifest files
+  when: item.j2_manifest is defined
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.set_fact:
+    _hotloop_template_files: >-
+      {{
+        _hotloop_template_files + [
+          {
+            'stage_name': item.name,
+            'file_path': _template_file_path,
+            'manifest_key': item.j2_manifest
+          }
+        ]
+      }}
+  vars:
+    _work_dir_template_result: "{{ _work_dir_template_check.results[ansible_loop.index0] }}"
+    _template_file_path: >-
+      {{
+        _work_dir_template_result.stat.path if _work_dir_template_result.stat.exists
+        else lookup('ansible.builtin.first_found', [item.j2_manifest])
+      }}
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+    extended: true
+
+- name: Check for kustomize directories in work_dir
+  when:
+    - item.kustomize is defined
+    - item.kustomize.directory is defined
+    - not item.kustomize.directory.startswith(('http://', 'https://'))
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.stat:
+    path: "{{ [work_dir, item.kustomize.directory] | ansible.builtin.path_join }}"
+  register: _work_dir_kustomize_check
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Collect kustomize directories
+  when:
+    - item.kustomize is defined
+    - item.kustomize.directory is defined
+    - not item.kustomize.directory.startswith(('http://', 'https://'))
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.set_fact:
+    _hotloop_kustomize_dirs: >-
+      {{
+        _hotloop_kustomize_dirs + [
+          {
+            'stage_name': item.name,
+            'dir_path': _kustomize_dir_path,
+            'kustomize_key': item.kustomize.directory
+          }
+        ]
+      }}
+  vars:
+    _work_dir_kustomize_result: "{{ _work_dir_kustomize_check.results[ansible_loop.index0] }}"
+    _kustomize_dir_path: >-
+      {{
+        _work_dir_kustomize_result.stat.path if _work_dir_kustomize_result.stat.exists
+        else lookup('ansible.builtin.first_found', [item.kustomize.directory])
+      }}
+  loop: "{{ __loaded_stages.outputs.stages }}"
+  loop_control:
+    label: "{{ item.name }}"
+    extended: true
+
+- name: Read static manifest files
+  when: _hotloop_static_files | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.slurp:
+    src: "{{ item.file_path }}"
+  register: _static_file_contents
+  loop: "{{ _hotloop_static_files }}"
+  loop_control:
+    label: "{{ item.stage_name }}: {{ item.manifest_key }}"
+
+- name: Store static file contents
+  when: _hotloop_static_files | length > 0
+  ansible.builtin.set_fact:
+    _hotloop_file_contents: >-
+      {{
+        _hotloop_file_contents | combine({
+          item.item.manifest_key: item.content | b64decode
+        })
+      }}
+  loop: "{{ _static_file_contents.results }}"
+  loop_control:
+    label: "{{ item.item.stage_name }}: {{ item.item.manifest_key }}"
+
+- name: Template manifest files on source host
+  when: _hotloop_template_files | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.template:
+    src: "{{ item.file_path }}"
+    dest: "/tmp/hotloop_{{ item.stage_name | regex_replace('[^a-zA-Z0-9_-]', '_') }}_{{ item.manifest_key | basename | splitext | first }}.yaml"
+  register: _template_file_results
+  loop: "{{ _hotloop_template_files }}"
+  loop_control:
+    label: "{{ item.stage_name }}: {{ item.manifest_key }}"
+
+- name: Read templated manifest files
+  when: _hotloop_template_files | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.slurp:
+    src: "{{ item.dest }}"
+  register: _template_file_contents
+  loop: "{{ _template_file_results.results }}"
+  loop_control:
+    label: "{{ item.item.stage_name }}: {{ item.item.manifest_key }}"
+
+- name: Store template file contents
+  when: _hotloop_template_files | length > 0
+  ansible.builtin.set_fact:
+    _hotloop_file_contents: >-
+      {{
+        _hotloop_file_contents | combine({
+          item.item.item.manifest_key: item.content | b64decode
+        })
+      }}
+  loop: "{{ _template_file_contents.results }}"
+  loop_control:
+    label: "{{ item.item.item.stage_name }}: {{ item.item.item.manifest_key }}"
+
+- name: Clean up temporary template files
+  when: _hotloop_template_files | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ _template_file_results.results }}"
+  loop_control:
+    label: "{{ item.item.stage_name }}: {{ item.item.manifest_key }}"
+
+- name: Archive kustomize directories
+  when: _hotloop_kustomize_dirs | length > 0
+  delegate_to: "{{ source_host }}"
+  community.general.archive:
+    path: "{{ item.dir_path }}"
+    dest: "/tmp/hotloop_kustomize_{{ item.stage_name | regex_replace('[^a-zA-Z0-9_-]', '_') }}.tar.gz"
+    format: gz
+  register: _kustomize_archives
+  loop: "{{ _hotloop_kustomize_dirs }}"
+  loop_control:
+    label: "{{ item.stage_name }}: {{ item.kustomize_key }}"
+
+- name: Read kustomize archives
+  when: _hotloop_kustomize_dirs | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.slurp:
+    src: "{{ item.dest }}"
+  register: _kustomize_archive_contents
+  loop: "{{ _kustomize_archives.results }}"
+  loop_control:
+    label: "{{ item.item.stage_name }}: {{ item.item.kustomize_key }}"
+
+- name: Store kustomize archive contents
+  when: _hotloop_kustomize_dirs | length > 0
+  ansible.builtin.set_fact:
+    _hotloop_file_contents: >-
+      {{
+        _hotloop_file_contents | combine({
+          ('kustomize_' + item.item.item.kustomize_key): item.content
+        })
+      }}
+  loop: "{{ _kustomize_archive_contents.results }}"
+  loop_control:
+    label: "{{ item.item.item.stage_name }}: {{ item.item.item.kustomize_key }}"
+
+- name: Clean up temporary kustomize archives
+  when: _hotloop_kustomize_dirs | length > 0
+  delegate_to: "{{ source_host }}"
+  ansible.builtin.file:
+    path: "{{ item.dest }}"
+    state: absent
+  loop: "{{ _kustomize_archives.results }}"
+  loop_control:
+    label: "{{ item.item.stage_name }}: {{ item.item.kustomize_key }}"

--- a/roles/hotloop/tasks/kustomize.yml
+++ b/roles/hotloop/tasks/kustomize.yml
@@ -32,8 +32,26 @@
     state: directory
     mode: '0755'
 
-- name: "Stage: {{ item.name }} :: Copy kustomize directory"
-  when: not _kustomize_is_url
+- name: "Stage: {{ item.name }} :: Extract kustomize directory (delegated)"
+  when:
+    - not _kustomize_is_url
+    - ansible_delegated_host is defined or source_host != 'localhost'
+  ansible.builtin.unarchive:
+    src: data:application/gzip;base64,{{ _hotloop_file_contents['kustomize_' + item.kustomize.directory] }}
+    dest: "{{ manifests_dir }}"
+    remote_src: true
+    creates: >-
+      {{
+        [
+          manifests_dir,
+          _kustomize_dir_name
+        ] | ansible.builtin.path_join
+      }}
+
+- name: "Stage: {{ item.name }} :: Copy kustomize directory (local)"
+  when:
+    - not _kustomize_is_url
+    - ansible_delegated_host is not defined and source_host == 'localhost'
   ansible.builtin.copy:
     src: >-
       {{

--- a/roles/hotloop/tasks/main.yml
+++ b/roles/hotloop/tasks/main.yml
@@ -38,6 +38,11 @@
     stages: "{{ automation.stages }}"
   register: __loaded_stages
 
+- name: Collect and pre-fetch files when delegating
+  when: ansible_delegated_host is defined or source_host != 'localhost'
+  ansible.builtin.include_tasks:
+    file: collect_files.yml
+
 - name: Execute automation stages
   ansible.builtin.include_tasks:
     file: execute_stage.yml

--- a/roles/hotloop/tasks/static_manifest.yml
+++ b/roles/hotloop/tasks/static_manifest.yml
@@ -29,12 +29,10 @@
 - name: "Stage: {{ item.name }} :: Copy manifest"
   ansible.builtin.copy:
     backup: true
-    src: >-
+    content: >-
       {{
-        [
-          work_dir,
-          item.manifest
-        ] | ansible.builtin.path_join
+        _hotloop_file_contents[item.manifest] if (ansible_delegated_host is defined or source_host != 'localhost')
+        else lookup('ansible.builtin.file', [work_dir, item.manifest] | ansible.builtin.path_join)
       }}
     dest: >-
       {{

--- a/roles/hotloop/tasks/template_manifest.yml
+++ b/roles/hotloop/tasks/template_manifest.yml
@@ -27,13 +27,11 @@
     mode: '0755'
 
 - name: "Stage: {{ item.name }} :: Template manifest"
-  ansible.builtin.template:
-    src: >-
+  ansible.builtin.copy:
+    content: >-
       {{
-        [
-          work_dir,
-          item.j2_manifest
-        ] | ansible.builtin.path_join
+        _hotloop_file_contents[item.j2_manifest] if (ansible_delegated_host is defined or source_host != 'localhost')
+        else lookup('ansible.builtin.template', [work_dir, item.j2_manifest] | ansible.builtin.path_join)
       }}
     dest: >-
       {{


### PR DESCRIPTION
Enables hotloop role to work when delegated to remote hosts by automatically pre-fetching files from source host.

- Add source_host parameter (defaults to localhost)
- Create collect_files.yml for file pre-fetching
- Update manifest tasks to use content: vs src:
- Handle kustomize dirs via archive/unarchive
- Add delegation detection in main.yml

Fixes "Could not find or access" errors when using:
  delegate_to: controller-0

Assisted-By: claude-4-sonnet