### PR TITLE
hotloop: Use rsync for delegation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ hotstack_cloud_secrets:
 ansible-galaxy collection install community.general
 ansible-galaxy collection install community.crypto
 ansible-galaxy collection install openstack.cloud
+ansible-galaxy collection install ansible.posix
 ```
 
 ## Bootstrap playbook

--- a/ci/playbooks/pre-commit.yml
+++ b/ci/playbooks/pre-commit.yml
@@ -23,6 +23,8 @@
         {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install community.general
         {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install community.crypto
         {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install openstack.cloud
+        {{ pre_commit_venv_dir }}/bin/ansible-galaxy collection install ansible.posix
+
     - name: Run pre-commit
       ansible.builtin.command:
         chdir: "{{ zuul.project.src_dir }}"

--- a/docs/deploy_hotstack_on_psi.md
+++ b/docs/deploy_hotstack_on_psi.md
@@ -111,12 +111,14 @@ pip install ansible
 
 HotStack depends on specific Ansible collections that provide modules for
 interacting with OpenStack and performing cryptographic operations. Install
-`community.general`, `community.crypto` and `openstack.cloud` collections.
+`community.general`, `ansible.posix`, `community.crypto` and `openstack.cloud`
+collections.
 
 ```bash
 ansible-galaxy collection install community.general
 ansible-galaxy collection install community.crypto
 ansible-galaxy collection install openstack.cloud
+ansible-galaxy collection install ansible.posix
 ```
 
 ##### OpenStack and Heat Client

--- a/docs/hotloop_lang.md
+++ b/docs/hotloop_lang.md
@@ -8,6 +8,7 @@ representing a distinct phase in the deployment or configuration process.
 ## Table of Contents
 
 - [Stages](#stages)
+- [Path Resolution](#path-resolution)
 - [Stage Types](#stage-types)
   - [1. `command` Stage](#1-command-stage)
   - [2. `shell` Stage](#2-shell-stage)
@@ -148,6 +149,21 @@ Here's a breakdown of the common attributes within a stage:
     run_conditions:
       - "{{ extra_stages is defined and extra_stages }}"
   ```
+
+## Path Resolution
+
+When specifying file paths in stage attributes (`manifest`, `j2_manifest`,
+`kustomize.directory`), the hotloop role handles them differently based on
+whether they are relative or absolute paths:
+
+- **Relative paths**: Automatically resolved within the synced work directory
+  that contains your scenario files. This is the recommended approach for
+  scenario-specific manifests and templates.
+
+- **Absolute paths** (starting with `/`): Must exist on the Ansible controller
+  host where the hotloop role is executed. These are typically used for
+  role-provided files (e.g., `{{ role_path }}/files/common/manifests/...`) or
+  system-wide resources.
 
 ## Stage Types
 

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -134,6 +134,13 @@
           }}
         mode: '0644'
 
+    - name: Add controller public key to inventory host authorized_keys
+      ansible.posix.authorized_key:
+        user: "{{ ansible_user_id }}"
+        key: "{{ dataplane_ssh_public_key }}"
+        comment: "controller-0 hotloop sync access"
+      delegate_to: "{{ inventory_hostname }}"
+
     - name: Copy dataplane authorized keys to controller
       ansible.builtin.copy:
         content: |

--- a/roles/hotloop/README.md
+++ b/roles/hotloop/README.md
@@ -227,6 +227,20 @@ stages:
       timeout: 180
 ```
 
+## Work Directory Isolation
+
+The hotloop role always creates an isolated work copy at
+`manifests_dir/hotloop_work/` before executing stages. This ensures:
+
+* Consistent behavior whether delegated or not
+* Safe operations that don't modify source files
+* Clean work environment for patches and modifications
+* Role files still found through Ansible's standard mechanisms
+
+**Important**: Any absolute paths (starting with `/`) specified in stage manifests
+must exist on the Ansible controller host where the hotloop role is executed.
+Relative paths are automatically resolved within the synced work directory.
+
 ## Example playbook
 
 ```yaml

--- a/roles/hotloop/tasks/kustomize.yml
+++ b/roles/hotloop/tasks/kustomize.yml
@@ -32,15 +32,25 @@
     state: directory
     mode: '0755'
 
+- name: "Stage: {{ item.name }} :: Check if kustomize directory exists in synced work directory"
+  when: not _kustomize_is_url and not item.kustomize.directory.startswith('/')
+  ansible.builtin.stat:
+    path: >-
+      {{
+        [_work_dir, item.kustomize.directory] |
+        ansible.builtin.path_join
+      }}
+  register: _synced_kustomize_stat
+
 - name: "Stage: {{ item.name }} :: Copy kustomize directory"
   when: not _kustomize_is_url
   ansible.builtin.copy:
+    remote_src: "{{ _synced_kustomize_stat.stat.exists | default(false) }}"
     src: >-
       {{
-        [
-          work_dir,
-          item.kustomize.directory
-        ] | ansible.builtin.path_join
+        [_work_dir, item.kustomize.directory] | ansible.builtin.path_join
+        if _synced_kustomize_stat.stat.exists | default(false)
+        else item.kustomize.directory
       }}/
     dest: >-
       {{

--- a/roles/hotloop/tasks/main.yml
+++ b/roles/hotloop/tasks/main.yml
@@ -25,6 +25,11 @@
       - manifests_dir is defined
       - manifests_dir | length > 0
 
+- name: Load stages
+  hotloop_stage_loader:
+    stages: "{{ automation.stages }}"
+  register: __loaded_stages
+
 - name: Ensure directory exists
   ansible.builtin.file:
     path: "{{ item }}"
@@ -33,12 +38,63 @@
   loop:
     - "{{ manifests_dir }}"
 
-- name: Load stages
-  hotloop_stage_loader:
-    stages: "{{ automation.stages }}"
-  register: __loaded_stages
+- name: Create work directory
+  ansible.builtin.file:
+    path: >-
+      {{
+        [manifests_dir, 'hotloop_work'] |
+        ansible.builtin.path_join
+      }}
+    state: directory
+    mode: '0755'
+
+- name: Sync work files to work directory
+  vars:
+    _source_host: >-
+      {{
+        hostvars[inventory_hostname]['ansible_host'] |
+        default(inventory_hostname)
+      }}
+    _source_path: "{{ [work_dir, ''] | ansible.builtin.path_join }}"
+    _target_path: >-
+      {{
+        [manifests_dir, 'hotloop_work', ''] |
+        ansible.builtin.path_join
+      }}
+    _is_local: >-
+      {{
+        hostvars[inventory_hostname]['ansible_connection'] |
+        default('') == 'local'
+      }}
+  block:
+    - name: Remove target directory for clean sync (local connection)
+      when: _is_local
+      ansible.builtin.file:
+        path: "{{ _target_path }}"
+        state: absent
+
+    - name: Copy work files (local connection)
+      when: _is_local
+      ansible.builtin.copy:
+        src: "{{ _source_path }}"
+        dest: "{{ _target_path }}"
+        mode: preserve
+
+    - name: Sync work files (remote connection)
+      when: not _is_local
+      ansible.posix.synchronize:
+        src: "{{ _source_host }}:{{ _source_path }}"
+        dest: "{{ _target_path }}"
+        delete: true
+        mode: pull
 
 - name: Execute automation stages
+  vars:
+    _work_dir: >-
+      {{
+        [manifests_dir, 'hotloop_work'] |
+        ansible.builtin.path_join
+      }}
   ansible.builtin.include_tasks:
     file: execute_stage.yml
   loop: "{{ __loaded_stages.outputs.stages }}"

--- a/roles/hotloop/tasks/static_manifest.yml
+++ b/roles/hotloop/tasks/static_manifest.yml
@@ -26,15 +26,25 @@
     state: directory
     mode: '0755'
 
+- name: "Stage: {{ item.name }} :: Check if manifest exists in synced work directory"
+  when: not item.manifest.startswith('/')
+  ansible.builtin.stat:
+    path: >-
+      {{
+        [_work_dir, item.manifest] |
+        ansible.builtin.path_join
+      }}
+  register: _synced_manifest_stat
+
 - name: "Stage: {{ item.name }} :: Copy manifest"
   ansible.builtin.copy:
     backup: true
+    remote_src: "{{ _synced_manifest_stat.stat.exists | default(false) }}"
     src: >-
       {{
-        [
-          work_dir,
-          item.manifest
-        ] | ansible.builtin.path_join
+        [_work_dir, item.manifest] | ansible.builtin.path_join
+        if _synced_manifest_stat.stat.exists | default(false)
+        else item.manifest
       }}
     dest: >-
       {{

--- a/roles/hotloop/tasks/template_manifest.yml
+++ b/roles/hotloop/tasks/template_manifest.yml
@@ -26,14 +26,24 @@
     state: directory
     mode: '0755'
 
+- name: "Stage: {{ item.name }} :: Check if j2_manifest exists in synced work directory"
+  when: not item.j2_manifest.startswith('/')
+  ansible.builtin.stat:
+    path: >-
+      {{
+        [_work_dir, item.j2_manifest] |
+        ansible.builtin.path_join
+      }}
+  register: _synced_j2_manifest_stat
+
 - name: "Stage: {{ item.name }} :: Template manifest"
   ansible.builtin.template:
+    remote_src: "{{ _synced_j2_manifest_stat.stat.exists | default(false) }}"
     src: >-
       {{
-        [
-          work_dir,
-          item.j2_manifest
-        ] | ansible.builtin.path_join
+        [_work_dir, item.j2_manifest] | ansible.builtin.path_join
+        if _synced_j2_manifest_stat.stat.exists | default(false)
+        else item.j2_manifest
       }}
     dest: >-
       {{


### PR DESCRIPTION
* Add SSH access from Hotstack controller to the inventory host for rsync pull operations.
* Add rsync task to sync scenario to potentially delegated host and update work_dir to point to synced location.
* Set `remote_src: true` conditionally on copy and template tasks in hotloop. If file is on the delegate to hosts work dir, use that - if not look for file on controller e.g. files that are in the role.
* If ansible connection is `local` a copy task is used instead of rsync pull.

Assisted-By: claude-4-sonnet