### PR TITLE
No lookup() in bootstap-vars

### DIFF
--- a/docs/deploy_hotstack_on_psi.md
+++ b/docs/deploy_hotstack_on_psi.md
@@ -253,6 +253,14 @@ command or configuration file.
 export OS_CLOUD=my_openstack_cloud_1
 ```
 
+### Inventory Configuration
+
+The `inventory.yml` file contains global configuration settings that apply to
+all scenarios. Key settings include:
+
+- `controller_ssh_pub_key`: SSH public key for the controller node. This is
+  centrally configured here and automatically available to all scenarios.
+
 ### Customizing bootstrap_vars.yml
 
 Each deployment scenario within the `scenarios/` directory (e.g.,

--- a/docs/hotstack_scenarios.md
+++ b/docs/hotstack_scenarios.md
@@ -28,7 +28,6 @@ networking, and other infrastructure settings.
 - **Key elements typically include:**
   - `os_cloud`, `os_floating_network`, `os_router_external_network`:
     OpenStack cloud and networking settings.
-  - `controller_ssh_pub_key`:  SSH public key for the controller node.
   - `scenario`, `scenario_dir`, `stack_template_path`,
     `automation_vars_file`: Paths and names related to the scenario's files.
   - `openstack_operators_image`, `openstack_operator_channel`,

--- a/inventory.yml
+++ b/inventory.yml
@@ -3,3 +3,5 @@ all:
   hosts:
     localhost:
       ansible_connection: local
+  vars:
+    controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"

--- a/scenarios/3-nodes-gitops/bootstrap_vars.yml
+++ b/scenarios/3-nodes-gitops/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: 3-nodes-gitops
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -40,7 +38,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/3-nodes/bootstrap_vars.yml
+++ b/scenarios/3-nodes/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: 3-nodes
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -40,7 +38,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/campus-ha/bootstrap_vars.yml
+++ b/scenarios/campus-ha/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: campus-ha
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -48,7 +46,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/compact-4-bm/bootstrap_vars.yml
+++ b/scenarios/compact-4-bm/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: compact-4-bm
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/hci/bootstrap_vars.yml
+++ b/scenarios/hci/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: hci
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -36,7 +34,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/multi-nodeset/bootstrap_vars.yml
+++ b/scenarios/multi-nodeset/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: multi-nodeset
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/multi-ns/bootstrap_vars.yml
+++ b/scenarios/multi-ns/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: multi-ns
 scenario_dir: scenarios
 
@@ -42,7 +40,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/snapshot-sno/bootstrap_vars.yml
+++ b/scenarios/snapshot-sno/bootstrap_vars.yml
@@ -6,8 +6,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: snapshot-sno
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -42,7 +40,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/sno-2-bm-flat-vlan/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm-flat-vlan/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: sno-2-bm-flat-vlan
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/sno-2-bm/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: sno-2-bm
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/sno-bmh-tests/bootstrap_vars.yml
+++ b/scenarios/sno-bmh-tests/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: sno-bmh-tests
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/sno-nxsw/bootstrap_vars.yml
+++ b/scenarios/sno-nxsw/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: sno-nxsw
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:

--- a/scenarios/uni01alpha/bootstrap_vars.yml
+++ b/scenarios/uni01alpha/bootstrap_vars.yml
@@ -3,8 +3,6 @@ os_cloud: default
 os_floating_network: public
 os_router_external_network: public
 
-controller_ssh_pub_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
-
 scenario: uni01alpha
 scenario_dir: scenarios
 stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
@@ -41,7 +39,7 @@ stack_parameters:
   #   mtu: 1442
   dns_servers: "{{ dns_servers }}"
   ntp_servers: "{{ ntp_servers }}"
-  controller_ssh_pub_key: "{{ controller_ssh_pub_key }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
   router_external_network: "{{ os_router_external_network | default('public') }}"
   floating_ip_network: "{{ os_floating_network | default('public') }}"
   controller_params:


### PR DESCRIPTION
The lookup to load the ssh-key caused issues when running as a job on RDO zuul. Move the lookup to the inventory instead so that there are no lookups in bootstrap-vars.

Assisted-By: claude-4-sonnet