### PR TITLE
redfish_virtual_bmc: no_log htpasswd task

### DIFF
--- a/roles/redfish_virtual_bmc/tasks/main.yml
+++ b/roles/redfish_virtual_bmc/tasks/main.yml
@@ -26,7 +26,9 @@
       ansible.builtin.dnf:
         name: httpd-tools
         state: present
+
     - name: Generate htpasswd
+      no_log: true
       register: _htpasswd
       ansible.builtin.command:
         cmd: "htpasswd -nbB {{ redfish_username | quote }} {{ redfish_password | quote }}"


### PR DESCRIPTION
It is ephemeral, but no need to log anyway.