### PR TITLE
Revert "redfish_virtual_bmc: no_log htpasswd task"

### DIFF
--- a/roles/redfish_virtual_bmc/tasks/main.yml
+++ b/roles/redfish_virtual_bmc/tasks/main.yml
@@ -28,7 +28,6 @@
         state: present
 
     - name: Generate htpasswd
-      no_log: true
       register: _htpasswd
       ansible.builtin.command:
         cmd: "htpasswd -nbB {{ redfish_username | quote }} {{ redfish_password | quote }}"


### PR DESCRIPTION
When using no_log the value does not register in
register: _htpasswd and the template {{ _htpasswd.stdout }} ends up have no result.

This reverts commit 116c397c92ef0b32958f665ab672475eeb5c0fae.