### PR TITLE
uni01alpha - Infra + Deploy RHOSO (No test execution)

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -131,3 +131,65 @@
     files:
       - ^scenarios/3-nodes/.*
       - ^roles/.*
+
+- job:
+    name: vexxhost-hotstack-uni01alpha
+    parent: base-hotstack
+    nodeset: hotstack-image-vexxhost
+    description: |
+      Hotstack scenario: uni01alpha
+    timeout: 10800
+    attempts: 1
+    vars:
+      cloud_name: vexxhost
+      scenario: uni01alpha
+      scenario_dir: >-
+        {{
+          [
+            ansible_user_dir,
+            zuul.projects['github.com/openstack-k8s-operators/hotstack'].src_dir,
+            'scenarios'
+          ] | ansible.builtin.path_join
+        }}
+      hotstack_overrides:
+        stack_parameters:
+          dns_servers:
+            - 199.204.44.24
+            - 199.204.47.54
+          ntp_servers: []
+          router_external_network: public
+          floating_ip_network: public
+          controller_params:
+            image: hotstack-controller
+            # vpu: 1 ram 2GB disk: 20GB
+            flavor: ci.m1.small
+          ocp_master_params:
+            image: ipxe-boot-usb
+            # vpu: 16 ram 48GB disk: 200GB
+            flavor: 12vcpu_32GB
+          ocp_worker_params:
+            image: ipxe-boot-usb
+            # vpu: 12 ram 32GB disk: 200GB
+            flavor: 12vcpu_32GB
+          compute_params:
+            image: cs9stream-genericcloud
+            # vpu: 2 ram 4GB disk: 40GB
+            flavor: ci.m1.medium
+          networker_params:
+            image: cs9stream-genericcloud
+            # vpu: 2 ram 4GB disk: 40GB
+            flavor: ci.m1.medium
+          bmh_params:
+            image: sushy-tools-blank-image
+            cd_image: sushy-tools-blank-image
+            # vpu: 2 ram 4GB disk: 40GB
+            flavor: ci.m1.medium
+          ironic_params:
+            image: sushy-tools-blank-image
+            cd_image: sushy-tools-blank-image
+            # vpu: 1 ram 2GB disk: 20GB
+            flavor: ci.m1.small
+    run:
+      - ci/playbooks/run-deploy.yml
+    files:
+      - ^scenarios/uni01alpha/.*

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,3 +11,4 @@
       jobs:
         - vexxhost-hotstack-sno-2-bm
         - vexxhost-hotstack-3-nodes
+        - vexxhost-hotstack-uni01alpha


### PR DESCRIPTION
A uni01alpha job that only deploys OCP and created the EDPM and ironic virtual baremetal nodes for this architecture.

UPDATE: Run the playbook to deploy RHOSO operators + openstack cloud. No test execution.