### PR TITLE
hotlogs: must-gather support OPENSTACK_DATABASES

### DIFF
--- a/roles/hotlogs/defaults/main.yml
+++ b/roles/hotlogs/defaults/main.yml
@@ -37,3 +37,4 @@ hotlogs_must_gather_image: "quay.io/openstack-k8s-operators/openstack-must-gathe
 hotlogs_must_gather_decompress: 0
 hotlogs_must_gather_sos_edpm: all
 hotlogs_must_gather_timeout: 10m
+hotlogs_must_gather_openstack_databases: "ALL"

--- a/roles/hotlogs/tasks/main.yml
+++ b/roles/hotlogs/tasks/main.yml
@@ -45,6 +45,7 @@
         additional_namespaces: "{{ hotlogs_must_gather_additional_namespaces }}"
         sos_edpm: "{{ hotlogs_must_gather_sos_edpm }}"
         sos_decompress: "{{ hotlogs_must_gather_decompress }}"
+        openstack_databases: "{{ hotlogs_must_gather_openstack_databases }}"
         compress: true
       register: must_gather_result
 


### PR DESCRIPTION
Add openstack_databases parameter to hotlogs_must_gather module, also enable collecting 'ALL' databases by default in the hotlogs role.

Assisted-By: claude-4-sonnet