### PR TITLE
Fix template manifest remote file handling

### DIFF
--- a/roles/hotloop/tasks/main.yml
+++ b/roles/hotloop/tasks/main.yml
@@ -44,6 +44,13 @@
     suffix: hotloop_work_temp
   register: _work_temp
 
+- name: Create temporary directory for templates
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: hotloop_templates
+  register: _templates_temp
+  delegate_to: localhost
+
 - name: Sync work files to work directory
   vars:
     _source_path: "{{ [work_dir, ''] | ansible.builtin.path_join }}"
@@ -87,6 +94,7 @@
 - name: Execute automation stages
   vars:
     _work_dir: "{{ _work_temp.path }}"
+    _templates_temp_dir: "{{ _templates_temp.path }}"
   ansible.builtin.include_tasks:
     file: execute_stage.yml
   loop: "{{ __loaded_stages.outputs.stages }}"
@@ -95,3 +103,9 @@
   ansible.builtin.file:
     path: "{{ _work_temp.path }}"
     state: absent
+
+- name: Remove temporary templates directory
+  ansible.builtin.file:
+    path: "{{ _templates_temp.path }}"
+    state: absent
+  delegate_to: localhost

--- a/roles/hotloop/tasks/template_manifest.yml
+++ b/roles/hotloop/tasks/template_manifest.yml
@@ -36,13 +36,19 @@
       }}
   register: _synced_j2_manifest_stat
 
+- name: "Stage: {{ item.name }} :: Fetch template from remote when needed"
+  when: _synced_j2_manifest_stat is defined and _synced_j2_manifest_stat.stat.exists | default(false)
+  ansible.builtin.fetch:
+    src: "{{ [_work_dir, item.j2_manifest] | ansible.builtin.path_join }}"
+    dest: "{{ _templates_temp_dir }}/{{ item.j2_manifest | ansible.builtin.basename }}"
+    flat: true
+
 - name: "Stage: {{ item.name }} :: Template manifest"
   ansible.builtin.template:
-    remote_src: "{{ _synced_j2_manifest_stat.stat.exists | default(false) }}"
     src: >-
       {{
-        [_work_dir, item.j2_manifest] | ansible.builtin.path_join
-        if _synced_j2_manifest_stat.stat.exists | default(false)
+        _templates_temp_dir + "/" + (item.j2_manifest | ansible.builtin.basename)
+        if _synced_j2_manifest_stat is defined and _synced_j2_manifest_stat.stat.exists | default(false)
         else item.j2_manifest
       }}
     dest: >-
@@ -62,7 +68,7 @@
         [
           manifests_dir,
           item.j2_manifest | dirname | ansible.builtin.basename,
-          item.j2_manifest | ansible.builtin.basename
+          item.j2_manifest | ansible.builtin.basename | ansible.builtin.splitext | first
         ] | ansible.builtin.path_join
       }}
     path: "{{ __patch.path }}"


### PR DESCRIPTION
Template module doesn't support remote_src like copy module. Implement fetch-then-template approach with role-wide temp directory management.

Also, fix patches task file extension and resolve
controller file access errors.

Assisted-By: claude-4-sonnet