### PR TITLE
WIP - Add MicroShift support

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -23,6 +23,9 @@
 - name: Install Openshift Container Platform
   ansible.builtin.import_playbook: 03-install_ocp.yml
 
+- name: Setup MicroShift
+  ansible.builtin.import_playbook: 03-setup_microshift.yml
+
 - name: Deploy RedFish Virtual BMC
   ansible.builtin.import_playbook: 04-redfish_virtual_bmc.yml
 

--- a/images/.gitignore
+++ b/images/.gitignore
@@ -1,9 +1,0 @@
-controller.qcow2
-controller.d/
-blank-image.qcow2
-nat64-appliance.qcow2
-switch-host.qcow2
-switch-host-base.qcow2
-.ci-framework/
-.nat64-build/
-.controller-build/

--- a/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/005-cluster-config/cluster-config-v1.yaml
+++ b/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/005-cluster-config/cluster-config-v1.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config-v1
+  namespace: kube-system
+  annotations:
+    description: "Minimal cluster config for MicroShift compatibility with OpenStack operators"
+data:
+  install-config: |
+    # MicroShift compatibility shim
+    # OpenStack operators check this ConfigMap to detect FIPS mode
+    # We fake this as false for MicroShift compatibility
+    fips: false

--- a/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/005-cluster-config/kustomization.yaml
+++ b/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/005-cluster-config/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-config-v1.yaml

--- a/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/030-metallb/kustomization.yaml
+++ b/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/030-metallb/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml
   - scc-bindings.yaml
+  - metallb-excludel2.yaml

--- a/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/035-frr-crds/kustomization.yaml
+++ b/images/dib/elements/hotstack-microshift/static/etc/microshift/manifests.d/035-frr-crds/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/metallb/frr-k8s/main/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+  - https://raw.githubusercontent.com/metallb/frr-k8s/main/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml

--- a/scenarios/microshift/README.md
+++ b/scenarios/microshift/README.md
@@ -1,0 +1,94 @@
+# microshift Scenario
+
+## Overview
+
+A MicroShift-based scenario designed to run the OpenStack control plane on a
+lightweight single-node Kubernetes cluster. This scenario uses a pre-built
+MicroShift image (built with `images/dib/microshift-image.yaml`) instead of
+a full Single Node OpenShift (SNO) installation.
+
+## Architecture
+
+### Component Details
+
+- **Controller**: Hotstack controller providing DNS, load balancing (HAProxy),
+  and orchestration services
+- **MicroShift**: Single-node MicroShift cluster running the OpenStack control
+  plane. Boots from a pre-built image with MicroShift packages installed;
+  runtime configuration (firewall, LVM, services) is applied via cloud-init.
+
+## Features
+
+- Pre-built MicroShift image for fast boot (no OCP agent-based installation)
+- Complete OpenStack service stack (Nova, Neutron, Glance, Swift, Ironic, etc.)
+- OpenStack Ironic bare metal provisioning service (no ironic nodes in the stack)
+- TopoLVM for local storage management
+- Cinder LVM-iSCSI backend
+- Multi-network setup for OpenStack services including Ironic provisioning network
+- Cloud-init based MicroShift runtime configuration
+
+## Networks
+
+- **machine-net**: 192.168.32.0/24 (MicroShift cluster network)
+- **ctlplane-net**: 192.168.122.0/24 (OpenStack control plane)
+- **internal-api-net**: 172.17.0.0/24 (OpenStack internal services)
+- **storage-net**: 172.18.0.0/24 (Storage backend communication)
+- **tenant-net**: 172.19.0.0/24 (Tenant network traffic)
+- **ironic-net**: 172.20.1.0/24 (Bare metal provisioning network)
+
+## OpenStack Services
+
+### Core Services
+
+- **Keystone**: Identity service with LoadBalancer on Internal API
+- **Nova**: Compute service with Ironic driver for bare metal
+- **Neutron**: Networking service with OVN backend
+- **Glance**: Image service with Swift backend
+- **Swift**: Object storage service
+- **Placement**: Resource placement service
+- **Cinder**: Block storage with LVM-iSCSI backend
+
+### Bare Metal Services
+
+- **Ironic**: Bare metal provisioning service
+- **Ironic Inspector**: Hardware inspection service
+- **Ironic Neutron Agent**: Network management for bare metal
+
+## MicroShift Image
+
+The MicroShift image is built using `images/dib/microshift-image.yaml` and
+includes:
+
+- CentOS 9 Stream base
+- MicroShift packages (core, networking, TopoLVM, OLM)
+- UEFI boot support
+
+Upload the image to your cloud:
+
+```bash
+openstack image create hotstack-microshift \
+  --disk-format raw \
+  --file microshift.qcow2 \
+  --property hw_firmware_type=uefi \
+  --property hw_machine_type=q35
+```
+
+## Usage
+
+```bash
+# Deploy the scenario
+ansible-playbook -i inventory.yml bootstrap.yml \
+  -e @scenarios/microshift/bootstrap_vars.yml \
+  -e @~/cloud-secrets.yaml
+```
+
+## Configuration Files
+
+- `bootstrap_vars.yml`: Infrastructure and MicroShift configuration
+- `automation-vars.yml`: Hotloop deployment stages
+- `heat_template.yaml`: OpenStack infrastructure template
+- `manifests/control-plane/control-plane.yaml.j2`: OpenStack service configuration
+- `manifests/control-plane/networking/nncp.yaml.j2`: Node network configuration
+- `manifests/control-plane/networking/nad.yaml`: Network attachment definitions
+- `manifests/control-plane/networking/metallb.yaml`: MetalLB load balancer pools
+- `manifests/control-plane/dnsmasq-dns-ironic.yaml`: DNS LoadBalancer on Ironic network

--- a/scenarios/microshift/automation-vars.yml
+++ b/scenarios/microshift/automation-vars.yml
@@ -1,0 +1,109 @@
+---
+stages:
+
+  - name: Cinder LVM
+    stages: >-
+      {{
+        lookup("ansible.builtin.file",
+               "common/stages/cinder-lvm-label-stages.yaml")
+      }}
+
+  - name: OLM Openstack
+    stages: >-
+      {{
+        lookup("ansible.builtin.template",
+               "common/stages/olm-openstack-stages.yaml.j2")
+      }}
+
+  - name: NodeNetworkConfigurationPolicy (nncp)
+    documentation: |
+      Apply node network configuration policies to configure host networking.
+      Waits for all policies to be successfully configured.
+    j2_manifest: manifests/control-plane/networking/nncp.yaml.j2
+    wait_conditions:
+      - >-
+        oc wait -n openstack nncp -l osp/nncm-config-type=standard
+        --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured
+        --timeout=180s
+
+  - name: NetworkAttchmentDefinition (NAD)
+    documentation: |
+      Create network attachment definitions for OpenStack services.
+      Defines additional network interfaces for pods.
+    manifest: manifests/control-plane/networking/nad.yaml
+
+  - name: MetalLB - L2Advertisement and IPAddressPool
+    documentation: |
+      Configure MetalLB load balancer with IP address pools and L2 advertisements.
+      Enables external access to OpenStack services.
+    manifest: manifests/control-plane/networking/metallb.yaml
+
+  - name: OpenstackControlPlane
+    documentation: |
+      Deploy the OpenStack control plane with all core services.
+      Waits for the control plane to be fully ready before proceeding.
+    j2_manifest: manifests/control-plane/control-plane.yaml.j2
+    wait_conditions:
+      - >-
+        oc -n openstack wait openstackcontrolplanes.core.openstack.org controlplane
+        --for condition=OpenStackControlPlaneDNSReadyCondition --timeout=600s
+
+  - name: Wait for OpenstackControlPlane
+    documentation: |
+      Wait for the OpenStack control plane to be fully ready and operational.
+      Ensures all services are running before proceeding with additional configurations.
+    wait_conditions:
+      - >-
+        oc wait -n openstack openstackcontrolplane controlplane
+        --for condition=Ready --timeout=30m
+
+  - name: Update openstack-operators OLM
+    stages: >-
+      {{
+        lookup('ansible.builtin.template',
+               'common/stages/openstack-olm-update.yaml.j2')
+      }}
+    run_conditions:
+      - >-
+        {{
+          openstack_operators_update is defined and
+          openstack_operators_update | bool
+        }}
+
+  - name: Wait for condition MinorUpdateAvailable True
+    documentation: |
+      Wait for OpenStack version to indicate a minor update is available.
+      Required before proceeding with version updates.
+    wait_conditions:
+      - >-
+        oc -n openstack wait openstackversions.core.openstack.org controlplane
+        --for=condition=MinorUpdateAvailable=True --timeout=10m
+    run_conditions:
+      - "{{ openstack_update is defined and openstack_update | bool }}"
+
+  - name: "Minor update :: Create OpenStackVersion patch"
+    documentation: |
+      This creates a patch file `{{ manifests_dir }}/patches/openstack_version_patch.yaml`
+      If `openstack_update_custom_images` is defined it will populate the customContainerImages
+      in the OpenstackVersion YAML patch.
+    shell: >-
+      {{
+        lookup('ansible.builtin.template',
+              'common/scripts/create_openstack_version_patch.sh.j2')
+      }}
+    run_conditions:
+      - "{{ openstack_update is defined and openstack_update | bool }}"
+
+  - name: "Minor update :: Update the target version in the OpenStackVersion custom resource (CR)"
+    documentation: |
+      The `hotstack-openstack-version-patch` script will get the `availableVersion`
+      and us it to replace the string `__TARGET_VERSION__` in the patch file and
+      apply the patch using `oc patch` command.
+    command: >-
+      hotstack-openstack-version-patch --namespace openstack --name controlplane
+      --file {{ manifests_dir }}/patches/openstack_version_patch.yaml
+    wait_conditions:
+      - oc -n openstack wait openstackversions.core.openstack.org controlplane
+        --for=condition=Ready --timeout=10m
+    run_conditions:
+      - "{{ openstack_update is defined and openstack_update | bool }}"

--- a/scenarios/microshift/bootstrap_vars.yml
+++ b/scenarios/microshift/bootstrap_vars.yml
@@ -1,0 +1,50 @@
+---
+os_cloud: default
+os_floating_network: public
+os_router_external_network: public
+
+scenario: microshift
+scenario_dir: scenarios
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
+
+openstack_operators_image: quay.io/openstack-k8s-operators/openstack-operator-index:latest
+openstack_operator_channel: alpha
+openstack_operator_starting_csv: null
+
+ntp_servers: []
+dns_servers:
+  - 172.31.0.129
+
+pull_secret_file: ~/pull-secret.txt
+
+ovn_k8s_gateway_config_host_routing: true
+enable_iscsi: true
+enable_multipath: true
+
+cinder_volume_pvs:
+  - /dev/vdc
+  - /dev/vdd
+  - /dev/vde
+
+# Nova console recorder NFS settings
+nova_console_recorder_nfs_server: controller-0.openstack.lab
+nova_console_recorder_nfs_path: /export/nova-console-recordings
+
+stack_name: "hs-{{ scenario }}-{{ zuul.build[:8] | default('no-zuul') }}"
+stack_parameters:
+  # On misconfigured clouds, uncomment these to avoid issues.
+  # Ref: https://access.redhat.com/solutions/7059376
+  # net_value_specs:
+  #   mtu: 1442
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  microshift_params:
+    image: hotstack-microshift
+    flavor: hotstack.xlarge

--- a/scenarios/microshift/files/microshift-config.yaml
+++ b/scenarios/microshift/files/microshift-config.yaml
@@ -1,0 +1,3 @@
+---
+dns:
+  baseDomain: shift.openstack.lab

--- a/scenarios/microshift/files/topolvm-configmap.yaml
+++ b/scenarios/microshift/files/topolvm-configmap.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: topolvm-lvmd-0
+  namespace: topolvm-system
+data:
+  lvmd.yaml: |
+    socket-name: /run/topolvm/lvmd.sock
+    device-classes:
+      - name: default
+        volume-group: microshift
+        spare-gb: 0
+        default: true

--- a/scenarios/microshift/files/topolvm-kustomization.yaml
+++ b/scenarios/microshift/files/topolvm-kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - storageclass.yaml

--- a/scenarios/microshift/files/topolvm-storageclass.yaml
+++ b/scenarios/microshift/files/topolvm-storageclass.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: lvms-local-storage
+provisioner: topolvm.io
+parameters:
+  topolvm.io/device-class: default
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/scenarios/microshift/heat_template.yaml
+++ b/scenarios/microshift/heat_template.yaml
@@ -1,0 +1,636 @@
+---
+heat_template_version: rocky
+
+description: >
+  Heat template for MicroShift scenario: 1x Controller, 1x MicroShift
+
+parameters:
+  dns_servers:
+    type: comma_delimited_list
+    default:
+      - 8.8.8.8
+      - 8.8.4.4
+  ntp_servers:
+    type: comma_delimited_list
+    default: []
+  controller_ssh_pub_key:
+    type: string
+  dataplane_ssh_pub_key:
+    type: string
+    default: ""
+  router_external_network:
+    type: string
+    default: public
+  floating_ip_network:
+    type: string
+    default: public
+  net_value_specs:
+    type: json
+    default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  nat64_appliance_params:
+    type: json
+    default:
+      image: nat64-appliance
+      flavor: hotstack.small
+  ocp_master_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  ocp_worker_params:
+    type: json
+    default:
+      image: ipxe-boot-usb
+      flavor: hotstack.xxlarge
+  compute_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.large
+  networker_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.small
+  bmh_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  ironic_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      cd_image: sushy-tools-blank-image
+      flavor: hotstack.medium
+  cdrom_disk_bus:
+    type: string
+    description: >
+      Disk bus type for CDROM device. 'sata' may be required for older versions
+      of OpenStack. Heat patch https://review.opendev.org/c/openstack/heat/+/966688
+      is needed for 'sata' support.
+    default: scsi
+    constraints:
+      - allowed_values:
+          - sata
+          - scsi
+  microshift_params:
+    type: json
+    default:
+      image: hotstack-microshift
+      flavor: hotstack.xlarge
+
+resources:
+  #
+  # Networks
+  #
+  machine-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  ctlplane-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  internal-api-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  storage-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  tenant-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  ironic-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  #
+  # Subnets
+  #
+  machine-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: machine-net}
+      ip_version: 4
+      cidr: 192.168.32.0/24
+      enable_dhcp: true
+      dns_nameservers:
+        - 192.168.32.254
+
+  ctlplane-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: ctlplane-net}
+      ip_version: 4
+      cidr: 192.168.122.0/24
+      enable_dhcp: false
+      allocation_pools:
+        - start: 192.168.122.100
+          end: 192.168.122.150
+
+  internal-api-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: internal-api-net}
+      ip_version: 4
+      cidr: 172.17.0.0/24
+      enable_dhcp: false
+      allocation_pools:
+        - start: 172.17.0.100
+          end: 172.17.0.150
+
+  storage-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: storage-net}
+      ip_version: 4
+      cidr: 172.18.0.0/24
+      enable_dhcp: false
+      allocation_pools:
+        - start: 172.18.0.100
+          end: 172.18.0.150
+
+  tenant-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: tenant-net}
+      ip_version: 4
+      cidr: 172.19.0.0/24
+      enable_dhcp: false
+      allocation_pools:
+        - start: 172.19.0.100
+          end: 172.19.0.150
+
+  ironic-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: ironic-net}
+      ip_version: 4
+      cidr: 172.20.1.0/24
+      enable_dhcp: false
+      allocation_pools: [{start: 172.20.1.100, end: 172.20.1.150}]
+
+  #
+  # Routers
+  #
+  router:
+    type: OS::Neutron::Router
+    properties:
+      admin_state_up: true
+      external_gateway_info:
+        network: {get_param: router_external_network}
+
+  machine-net-router-interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: router}
+      subnet: {get_resource: machine-subnet}
+
+  ctlplane-net-router-interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: router}
+      subnet: {get_resource: ctlplane-subnet}
+
+  ironic-net-router-interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: router}
+      subnet: {get_resource: ironic-subnet}
+
+  #
+  # Controller
+  #
+  controller_users:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        users:
+          - default
+          - name: zuul
+            gecos: "Zuul user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+
+  controller-write-files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+          - path: /etc/dnsmasq.conf
+            content: |
+              # dnsmasq service config
+              # Include all files in /etc/dnsmasq.d except RPM backup files
+              conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig
+              no-resolv
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/forwarders.conf
+            content:
+              str_replace:
+                template: |
+                  # DNS forwarders records
+                  server=$dns1
+                  server=$dns2
+                params:
+                  $dns1: {get_param: [dns_servers, 0]}
+                  $dns2: {get_param: [dns_servers, 1]}
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/host_records.conf
+            content:
+              str_replace:
+                template: |
+                  # Host records
+                  host-record=controller-0.openstack.lab,$controller0
+                  host-record=microshift-0.shift.openstack.lab,$microshift0
+                params:
+                  $controller0: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+                  $microshift0: {get_attr: [microshift0-machine-port, fixed_ips, 0, ip_address]}
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/wildcard_records.conf
+            content:
+              str_replace:
+                template: |
+                  # Wildcard records
+                  address=/apps.shift.openstack.lab/$addr
+                params:
+                  $addr: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+            owner: root:dnsmasq
+          - path: /etc/resolv.conf
+            content: |
+              nameserver: 127.0.0.1
+            owner: root:root
+          - path: /etc/NetworkManager/conf.d/98-rc-manager.conf
+            content: |
+              [main]
+              rc-manager=unmanaged
+            owner: root:root
+          - path: /etc/haproxy/haproxy.cfg
+            content: |
+              global
+                log         127.0.0.1 local2
+                pidfile     /var/run/haproxy.pid
+                maxconn     4000
+                daemon
+              defaults
+                mode                    http
+                log                     global
+                option                  dontlognull
+                option                  http-server-close
+                option                  redispatch
+                retries                 3
+                timeout http-request    10s
+                timeout queue           1m
+                timeout connect         10s
+                timeout client          1m
+                timeout server          1m
+                timeout http-keep-alive 10s
+                timeout check           10s
+                maxconn                 3000
+              listen api-server-6443
+                bind *:6443
+                mode tcp
+                server microshift-0 microshift-0.shift.openstack.lab:6443 check inter 1s
+              listen ingress-router-443
+                bind *:443
+                mode tcp
+                balance source
+                server microshift-0 microshift-0.shift.openstack.lab:443 check inter 1s
+              listen ingress-router-80
+                bind *:80
+                mode tcp
+                balance source
+                server microshift-0 microshift-0.shift.openstack.lab:80 check inter 1s
+            owner: root:root
+
+  controller-runcmd:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        runcmd:
+          - ['systemctl', 'enable', 'dnsmasq.service']
+          - ['systemctl', 'start', 'dnsmasq.service']
+          - ['setenforce', 'permissive']
+          - ['systemctl', 'enable', 'haproxy.service']
+          - ['systemctl', 'start', 'haproxy.service']
+
+  controller-init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: {get_resource: controller_users}
+        - config: {get_resource: controller-write-files}
+        - config: {get_resource: controller-runcmd}
+
+  controller-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
+      fixed_ips:
+        - ip_address: 192.168.32.254
+
+  controller-floating-ip:
+    depends_on: machine-net-router-interface
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: floating_ip_network}
+      port_id: {get_resource: controller-machine-port}
+
+  controller:
+    type: OS::Nova::Server
+    properties:
+      image: {get_param: [controller_params, image]}
+      flavor: {get_param: [controller_params, flavor]}
+      networks:
+        - port: {get_resource: controller-machine-port}
+      user_data_format: RAW
+      user_data: {get_resource: controller-init}
+
+  #
+  # MicroShift
+  #
+  microshift0-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:10"
+      fixed_ips:
+        - ip_address: 192.168.32.10
+
+  microshift0-ctlplane-trunk-parent-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ctlplane-net}
+      port_security_enabled: false
+      fixed_ips:
+        - ip_address: 192.168.122.10
+
+  microshift0-internal-api-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: internal-api-net}
+      port_security_enabled: false
+      fixed_ips:
+        - ip_address: 172.17.0.10
+
+  microshift0-storage-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: storage-net}
+      port_security_enabled: false
+      fixed_ips:
+        - ip_address: 172.18.0.10
+
+  microshift0-tenant-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-net}
+      port_security_enabled: false
+      fixed_ips:
+        - ip_address: 172.19.0.10
+
+  microshift0-ironic-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ironic-net}
+      port_security_enabled: false
+      fixed_ips: [{ip_address: 172.20.1.10}]
+
+  microshift0-trunk0:
+    type: OS::Neutron::Trunk
+    properties:
+      port: {get_resource: microshift0-ctlplane-trunk-parent-port}
+      sub_ports:
+        - port: {get_resource: microshift0-internal-api-port}
+          segmentation_id: 20
+          segmentation_type: vlan
+        - port: {get_resource: microshift0-storage-port}
+          segmentation_id: 21
+          segmentation_type: vlan
+        - port: {get_resource: microshift0-tenant-port}
+          segmentation_id: 22
+          segmentation_type: vlan
+
+  microshift0-lvms-vol0:
+    type: OS::Cinder::Volume
+    properties:
+      size: 40
+
+  microshift0-cinder-vol0:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  microshift0-cinder-vol1:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  microshift0-cinder-vol2:
+    type: OS::Cinder::Volume
+    properties:
+      size: 20
+
+  microshift_users:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        users:
+          - default
+          - name: shift
+            gecos: "MicroShift user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+              - {get_param: dataplane_ssh_pub_key}
+
+  microshift-hostname:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        fqdn: microshift-0.shift.openstack.lab
+        prefer_fqdn_over_hostname: true
+
+  microshift-write-files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+          - path: /etc/microshift/config.yaml
+            content: {get_file: files/microshift-config.yaml}
+            owner: root:root
+          - path: /etc/microshift/manifests.d/002-topolvm-config/kustomization.yaml
+            content: {get_file: files/topolvm-kustomization.yaml}
+            owner: root:root
+          - path: /etc/microshift/manifests.d/002-topolvm-config/configmap.yaml
+            content: {get_file: files/topolvm-configmap.yaml}
+            owner: root:root
+          - path: /etc/microshift/manifests.d/002-topolvm-config/storageclass.yaml
+            content: {get_file: files/topolvm-storageclass.yaml}
+            owner: root:root
+          - path: /etc/microshift/ovn.yaml
+            content:
+              str_replace:
+                template: |
+                  # MTU value to be used for the Pods, must be less than or equal
+                  # to the MTU of default route interface.
+                  mtu: $mtu
+                params:
+                  $mtu: {get_attr: [machine-net, mtu]}
+            owner: root:root
+
+  microshift-runcmd:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        runcmd:
+          - ['/usr/sbin/pvcreate', '/dev/vdb', '/dev/vdc', '/dev/vdd', '/dev/vde']
+          - ['/usr/sbin/vgcreate', 'microshift', '/dev/vdb']
+          - ['/usr/sbin/vgcreate', 'cinder-volumes', '/dev/vdc', '/dev/vdd', '/dev/vde']
+
+  microshift-init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: {get_resource: microshift_users}
+        - config: {get_resource: microshift-hostname}
+        - config: {get_resource: microshift-write-files}
+        - config: {get_resource: microshift-runcmd}
+
+  microshift0:
+    type: OS::Nova::Server
+    properties:
+      image: {get_param: [microshift_params, image]}
+      flavor: {get_param: [microshift_params, flavor]}
+      block_device_mapping_v2:
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: microshift0-lvms-vol0}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: microshift0-cinder-vol0}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: microshift0-cinder-vol1}
+        - boot_index: -1
+          device_type: disk
+          volume_id: {get_resource: microshift0-cinder-vol2}
+      networks:
+        - port: {get_resource: microshift0-machine-port}
+        - port: {get_attr: [microshift0-trunk0, port_id]}
+        - port: {get_resource: microshift0-ironic-port}
+      user_data_format: RAW
+      user_data: {get_resource: microshift-init}
+
+
+outputs:
+  ocp_installer_type:
+    description: OpenShift installer type
+    value: microshift
+
+  ocp_node_hostname:
+    description: Kubernetes node hostname (FQDN)
+    value: microshift-0.shift.openstack.lab
+
+  ocp_install_config:
+    description: >
+      Stub for compatibility with playbooks that derive the ingress domain
+      from ocp_install_config.metadata.name and ocp_install_config.baseDomain.
+    value:
+      metadata:
+        name: shift
+      baseDomain: openstack.lab
+
+  controller_floating_ip:
+    description: Controller Floating IP
+    value: {get_attr: [controller-floating-ip, floating_ip_address]}
+
+  network_mtu:
+    description: MTU values for all networks
+    value:
+      machine: {get_attr: [machine-net, mtu]}
+      ctlplane: {get_attr: [ctlplane-net, mtu]}
+      internal_api: {get_attr: [internal-api-net, mtu]}
+      storage: {get_attr: [storage-net, mtu]}
+      tenant: {get_attr: [tenant-net, mtu]}
+      ironic: {get_attr: [ironic-net, mtu]}
+
+  controller_ansible_host:
+    description: >
+      Controller ansible host, this struct can be passed to the ansible.builtin.add_host module
+    value:
+      name: controller-0
+      ansible_ssh_user: zuul
+      ansible_host: {get_attr: [controller-floating-ip, floating_ip_address]}
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+      groups: controllers
+
+  microshift_ansible_host:
+    description: >
+      MicroShift ansible host, this struct can be passed to the ansible.builtin.add_host module.
+      Uses ProxyJump through the controller for SSH access.
+    value:
+      name: microshift-0
+      ansible_user: shift
+      ansible_host: {get_attr: [microshift0-machine-port, fixed_ips, 0, ip_address]}
+      ansible_port: 22
+      ansible_ssh_common_args:
+        str_replace:
+          template: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump=zuul@$controller_ip'
+          params:
+            $controller_ip: {get_attr: [controller-floating-ip, floating_ip_address]}
+      ansible_ssh_private_key_file: '~/.ssh/id_rsa'
+      groups: microshifts
+
+  ansible_inventory:
+    description: Ansible inventory
+    value:
+      all:
+        children:
+          controllers:
+            vars:
+          microshifts:
+            vars:
+      localhosts:
+        hosts:
+          localhost:
+            ansible_connection: local
+      controllers:
+        hosts:
+          controller0:
+            ansible_host: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+            ansible_user: zuul
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
+      microshifts:
+        hosts:
+          microshift0:
+            ansible_host: {get_attr: [microshift0-machine-port, fixed_ips, 0, ip_address]}
+            ansible_user: shift
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+            ansible_ssh_private_key_file: '~/.ssh/id_rsa'

--- a/scenarios/microshift/manifests/control-plane/control-plane.yaml.j2
+++ b/scenarios/microshift/manifests/control-plane/control-plane.yaml.j2
@@ -1,0 +1,241 @@
+{% raw %}
+---
+apiVersion: v1
+data:
+  server-ca-passphrase: MTIzNDU2Nzg=
+kind: Secret
+metadata:
+  name: octavia-ca-passphrase
+  namespace: openstack
+type: Opaque
+---
+apiVersion: v1
+data:
+  AdminPassword: MTIzNDU2Nzg=
+  AodhDatabasePassword: MTIzNDU2Nzg=
+  AodhPassword: MTIzNDU2Nzg=
+  BarbicanDatabasePassword: MTIzNDU2Nzg=
+  BarbicanPassword: MTIzNDU2Nzg=
+  BarbicanSimpleCryptoKEK: r0wDZ1zrD5upafX9RDfYqvDkW2LENBWH7Gz9+Tr3NdM=
+  CeilometerPassword: MTIzNDU2Nzg=
+  CinderDatabasePassword: MTIzNDU2Nzg=
+  CinderPassword: MTIzNDU2Nzg=
+  DatabasePassword: MTIzNDU2Nzg=
+  DbRootPassword: MTIzNDU2Nzg=
+  DesignateDatabasePassword: MTIzNDU2Nzg=
+  DesignatePassword: MTIzNDU2Nzg=
+  GlanceDatabasePassword: MTIzNDU2Nzg=
+  GlancePassword: MTIzNDU2Nzg=
+  HeatAuthEncryptionKey: NzY3YzNlZDA1NmNiYWEzYjlkZmVkYjhjNmY4MjViZjA=
+  HeatDatabasePassword: MTIzNDU2Nzg=
+  HeatPassword: MTIzNDU2Nzg=
+  IronicDatabasePassword: MTIzNDU2Nzg=
+  IronicInspectorDatabasePassword: MTIzNDU2Nzg=
+  IronicInspectorPassword: MTIzNDU2Nzg=
+  IronicPassword: MTIzNDU2Nzg=
+  KeystoneDatabasePassword: MTIzNDU2Nzg=
+  ManilaDatabasePassword: MTIzNDU2Nzg=
+  ManilaPassword: MTIzNDU2Nzg=
+  MetadataSecret: MTIzNDU2Nzg0Mg==
+  NeutronDatabasePassword: MTIzNDU2Nzg=
+  NeutronPassword: MTIzNDU2Nzg=
+  NovaAPIDatabasePassword: MTIzNDU2Nzg=
+  NovaCell0DatabasePassword: MTIzNDU2Nzg=
+  NovaCell1DatabasePassword: MTIzNDU2Nzg=
+  NovaPassword: MTIzNDU2Nzg=
+  OctaviaDatabasePassword: MTIzNDU2Nzg=
+  OctaviaHeartbeatKey: MTIzNDU2Nzg=
+  OctaviaPassword: MTIzNDU2Nzg=
+  PlacementDatabasePassword: MTIzNDU2Nzg=
+  PlacementPassword: MTIzNDU2Nzg=
+  SwiftPassword: MTIzNDU2Nzg=
+kind: Secret
+metadata:
+  name: osp-secret
+  namespace: openstack
+type: Opaque
+---
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: controlplane
+  namespace: openstack
+spec:
+  barbican:
+    enabled: false
+  ceilometer:
+    enabled: false
+  cinder:
+    enabled: false
+  designate:
+    enabled: false
+  dns:
+    template:
+      options:
+      - key: server
+        values:
+        - 192.168.32.254
+      override:
+        service:
+          metadata:
+            annotations:
+              metallb.io/address-pool: ctlplane
+              metallb.io/loadBalancerIPs: 192.168.122.80
+          spec:
+            type: LoadBalancer
+      replicas: 1
+  galera:
+    enabled: true
+    templates:
+      openstack:
+        replicas: 1
+        secret: osp-secret
+        storageRequest: 5G
+  glance:
+    enabled: false
+  heat:
+    enabled: false
+  horizon:
+    enabled: false
+  ironic:
+    enabled: false
+  keystone:
+    apiOverride:
+      route: {}
+    template:
+      databaseInstance: openstack
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.io/address-pool: internalapi
+                metallb.io/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
+      preserveJobs: false
+      replicas: 1
+      secret: osp-secret
+  manila:
+    enabled: false
+  memcached:
+    templates:
+      memcached:
+        replicas: 1
+  neutron:
+    enabled: false
+    apiOverride:
+      route: {}
+    template:
+      customServiceConfig: |
+        [DEFAULT]
+        vlan_transparent = true
+        agent_down_time = 600
+        router_distributed = true
+        router_scheduler_driver = neutron.scheduler.l3_agent_scheduler.ChanceScheduler
+        allow_automatic_l3agent_failover = true
+        debug = true
+
+        [agent]
+        report_interval = 300
+
+        [database]
+        max_retries = -1
+        db_max_retries = -1
+
+        [keystone_authtoken]
+        region_name = regionOne
+        memcache_use_advanced_pool = True
+
+        [oslo_messaging_notifications]
+        driver = noop
+
+        [oslo_middleware]
+        enable_proxy_headers_parsing = true
+
+        [oslo_policy]
+        policy_file = /etc/neutron/policy.yaml
+
+        [ovs]
+        igmp_snooping_enable = true
+
+        [ovn]
+        ovsdb_probe_interval = 60000
+        ovn_emit_need_to_frag = true
+
+        [ml2]
+{% endraw %}
+        global_physnet_mtu = {{ stack_outputs.network_mtu.ctlplane }}
+        path_mtu = {{ stack_outputs.network_mtu.tenant }}
+{% raw %}
+        type_drivers = geneve,vxlan,vlan,flat,local
+        tenant_network_types = geneve,flat
+      ml2MechanismDrivers:
+      - ovn
+      - baremetal
+      databaseInstance: openstack
+      networkAttachments:
+      - internalapi
+      override:
+        service:
+          internal:
+            metadata:
+              annotations:
+                metallb.io/address-pool: internalapi
+                metallb.io/loadBalancerIPs: 172.17.0.80
+            spec:
+              type: LoadBalancer
+      preserveJobs: false
+      replicas: 1
+      secret: osp-secret
+  nova:
+    enabled: false
+  octavia:
+    enabled: false
+  ovn:
+    template:
+      ovnController:
+        networkAttachment: tenant
+        nicMappings:
+          datacentre: ocpbr
+          ironic: ironic
+      ovnDBCluster:
+        ovndbcluster-nb:
+          dbType: NB
+          networkAttachment: internalapi
+          replicas: 1
+          storageRequest: 10G
+        ovndbcluster-sb:
+          dbType: SB
+          networkAttachment: internalapi
+          replicas: 1
+          storageRequest: 10G
+      ovnNorthd:
+        logLevel: info
+        nThreads: 1
+        replicas: 1
+        resources: {}
+        tls: {}
+  placement:
+    enabled: false
+  rabbitmq:
+    templates:
+      rabbitmq:
+        override:
+          service:
+            metadata:
+              annotations:
+                metallb.io/address-pool: internalapi
+                metallb.io/loadBalancerIPs: 172.17.0.85
+            spec:
+              type: LoadBalancer
+        replicas: 1
+  secret: osp-secret
+  storageClass: lvms-local-storage
+  notificationsBus:
+    cluster: rabbitmq
+  swift:
+    enabled: false
+  telemetry:
+    enabled: false
+{% endraw %}

--- a/scenarios/microshift/manifests/control-plane/dnsmasq-dns-ironic.yaml
+++ b/scenarios/microshift/manifests/control-plane/dnsmasq-dns-ironic.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    core.openstack.org/ingress_create: "false"
+    metallb.io/ip-allocated-from-pool: ironic
+    metallb.io/address-pool: ironic
+    metallb.io/loadBalancerIPs: 172.20.1.80
+  name: dnsmasq-dns-ironic
+  namespace: openstack
+  labels:
+    service: dnsmasq
+spec:
+  ports:
+    - name: dnsmasq
+      port: 53
+      protocol: UDP
+      targetPort: 5353
+    - name: dnsmasq-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 5353
+  selector:
+    service: dnsmasq
+  type: LoadBalancer

--- a/scenarios/microshift/manifests/control-plane/networking/metallb.yaml
+++ b/scenarios/microshift/manifests/control-plane/networking/metallb.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  labels:
+    osp/lb-addresses-type: standard
+  name: ctlplane
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.122.80-192.168.122.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  labels:
+    osp/lb-addresses-type: standard
+  name: internalapi
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.0.80-172.17.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  labels:
+    osp/lb-addresses-type: standard
+  name: storage
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.0.80-172.18.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  labels:
+    osp/lb-addresses-type: standard
+  name: tenant
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.19.0.80-172.19.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  labels:
+    osp/lb-addresses-type: standard
+  name: ironic
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.20.1.80-172.20.1.90
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ctlplane
+  namespace: metallb-system
+spec:
+  interfaces:
+  - ospbr
+  ipAddressPools:
+  - ctlplane
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: internalapi
+  namespace: metallb-system
+spec:
+  interfaces:
+  - internalapi
+  ipAddressPools:
+  - internalapi
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: storage
+  namespace: metallb-system
+spec:
+  interfaces:
+  - storage
+  ipAddressPools:
+  - storage
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: tenant
+  namespace: metallb-system
+spec:
+  interfaces:
+  - tenant
+  ipAddressPools:
+  - tenant
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ironic
+  namespace: metallb-system
+spec:
+  interfaces:
+  - ironic
+  ipAddressPools:
+  - ironic

--- a/scenarios/microshift/manifests/control-plane/networking/nad.yaml
+++ b/scenarios/microshift/manifests/control-plane/networking/nad.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: ctlplane
+    osp/net-attach-def-type: standard
+  name: ctlplane
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "ctlplane",
+      "type": "macvlan",
+      "master": "ospbr",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.122.0/24",
+        "range_start": "192.168.122.30",
+        "range_end": "192.168.122.70"
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: ironic
+    osp/net-attach-def-type: standard
+  name: ironic
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "ironic",
+      "type": "bridge",
+      "bridge": "ironic",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.20.1.0/24",
+        "range_start": "172.20.1.30",
+        "range_end": "172.20.1.70"
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: datacentre
+    osp/net-attach-def-type: standard
+  name: datacentre
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "datacentre",
+      "type": "bridge",
+      "bridge": "ospbr",
+      "ipam": {}
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: internalapi
+    osp/net-attach-def-type: standard
+  name: internalapi
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "internalapi",
+      "type": "macvlan",
+      "master": "internalapi",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.17.0.0/24",
+        "range_start": "172.17.0.30",
+        "range_end": "172.17.0.70"
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: storage
+    osp/net-attach-def-type: standard
+  name: storage
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "storage",
+      "type": "macvlan",
+      "master": "storage",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.18.0.0/24",
+        "range_start": "172.18.0.30",
+        "range_end": "172.18.0.70"
+      }
+    }
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: tenant
+    osp/net-attach-def-type: standard
+  name: tenant
+  namespace: openstack
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "tenant",
+      "type": "macvlan",
+      "master": "tenant",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.19.0.0/24",
+        "range_start": "172.19.0.30",
+        "range_end": "172.19.0.70"
+      }
+    }

--- a/scenarios/microshift/manifests/control-plane/networking/nncp.yaml.j2
+++ b/scenarios/microshift/manifests/control-plane/networking/nncp.yaml.j2
@@ -1,0 +1,108 @@
+---
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp/nncm-config-type: standard
+  name: {{ stack_outputs.ocp_node_hostname | default('master-0') }}
+  namespace: openstack
+spec:
+  desiredState:
+    interfaces:
+    - name: internalapi
+      type: vlan
+      description: internalapi vlan interface
+      ipv4:
+        address:
+        - ip: 172.17.0.10
+          prefix-length: "24"
+        dhcp: false
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: {{ stack_outputs.network_mtu.internal_api }}
+      state: up
+      vlan:
+        base-iface: eth1
+        id: "20"
+    - name: storage
+      type: vlan
+      description: storage vlan interface
+      ipv4:
+        address:
+        - ip: 172.18.0.10
+          prefix-length: "24"
+        dhcp: false
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: {{ stack_outputs.network_mtu.storage }}
+      state: up
+      vlan:
+        base-iface: eth1
+        id: "21"
+    - name: tenant
+      type: vlan
+      description: tenant vlan interface
+      ipv4:
+        address:
+        - ip: 172.19.0.10
+          prefix-length: "24"
+        dhcp: false
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: {{ stack_outputs.network_mtu.tenant }}
+      state: up
+      vlan:
+        base-iface: eth1
+        id: "22"
+    - description: ctlplane interface
+      mtu: {{ stack_outputs.network_mtu.ctlplane }}
+      name: eth1
+      state: up
+      type: ethernet
+    - name: ospbr
+      type: linux-bridge
+      description: linux-bridge over ctlplane interface
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: eth1
+          vlan: {}
+      ipv4:
+        address:
+        - ip: 192.168.122.10
+          prefix-length: "24"
+        dhcp: false
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: {{ stack_outputs.network_mtu.ctlplane }}
+      state: up
+    - name: ironic
+      type: linux-bridge
+      description: Ironic bridge
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: eth2
+      ipv4:
+        address:
+        - ip: 172.20.1.10
+          prefix-length: "24"
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: {{ stack_outputs.network_mtu.ironic }}
+    route-rules:
+      config: []
+    routes:
+      config: []
+  nodeSelector:
+    kubernetes.io/hostname: {{ stack_outputs.ocp_node_hostname | default('master-0') }}
+    node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
Introduces disk image building elements, Ansible roles, Heat templates, and bootstrap/setup playbooks for deploying MicroShift as an alternative to OCP.

Assisted-By: Claude (claude-4.5-sonnet)