### PR TITLE
Fix SONiC image name mismatch in import service

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/README.rst
+++ b/images/dib/elements/hotstack-sonic-vs/README.rst
@@ -35,7 +35,7 @@ The config file contains shell-style variables for the host configuration:
 - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
 - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
 - SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-- SONIC_IMAGE: Podman image tag (default: localhost/sonic:latest)
+- SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:latest)
 
 Host interfaces are moved directly into the container namespace:
 - Host eth1 -> Container eth0 (SONiC Management0)

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
@@ -12,7 +12,7 @@ config
   - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
   - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
   - SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-  - SONIC_IMAGE: Podman image tag (default: localhost/sonic:latest)
+  - SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:latest)
 
 config_db.json
   SONiC native configuration file in JSON format. This file is mounted

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic-import.service
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic-import.service
@@ -22,11 +22,9 @@ ConditionPathExists=!/var/lib/sonic/.image-imported
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash -c 'VERSION=$(cat /var/lib/sonic/sonic-version.txt 2>/dev/null || echo latest); \
-    podman load -i /var/lib/sonic/sonic-image.tar.gz && \
-    podman tag localhost/sonic:$VERSION localhost/sonic:latest && \
+ExecStart=/bin/bash -c 'podman load -i /var/lib/sonic/sonic-image.tar.gz && \
     touch /var/lib/sonic/.image-imported && \
-    echo "SONiC image loaded as sonic:$VERSION"'
+    echo "SONiC image loaded successfully"'
 
 [Install]
 WantedBy=multi-user.target

--- a/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
@@ -53,7 +53,7 @@ class SonicConfig:
         self.switch_interface_start = "eth1"
         self.switch_interface_count = 5
         self.switch_hostname = "sonic"
-        self.sonic_image = "localhost/sonic:latest"
+        self.sonic_image = "localhost/docker-sonic-vs:latest"
 
     def load_from_file(self, config_file: str = CONFIG_FILE) -> None:
         """Load configuration from shell-style config file.


### PR DESCRIPTION
Use actual image name from archive (docker-sonic-vs) instead of attempting to retag. Simplifies import service logic.

Assisted-By: Claude (claude-4.5-sonnet)