### PR TITLE
SONiC container startup, add sonic_version.yml

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
@@ -18,6 +18,14 @@ config_db.json
   SONiC native configuration file in JSON format. This file is mounted
   into the SONiC container at /etc/sonic/config_db.json.
 
+frr.conf
+  FRRouting configuration file. This file is mounted into the SONiC
+  container at /etc/frr/frr.conf.
+
+sonic_version.yml
+  SONiC version information file. Required by SONiC services. If not
+  provided, a default version file will be used.
+
 Usage with cloud-init
 ----------------------
 

--- a/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
@@ -37,11 +37,14 @@ LOG = logging.getLogger(__name__)
 CONFIG_FILE = "/etc/hotstack-sonic/config"
 CONFIG_DB_FILE = "/etc/hotstack-sonic/config_db.json"
 FRR_CONF_FILE = "/etc/hotstack-sonic/frr.conf"
+SONIC_VERSION_FILE = "/etc/hotstack-sonic/sonic_version.yml"
 SONIC_DIR = "/var/lib/sonic"
 SONIC_CONFIG_DB = "/var/lib/sonic/config_db.json"
 SONIC_FRR_CONF = "/var/lib/sonic/frr.conf"
+SONIC_VERSION_YML = "/var/lib/sonic/sonic_version.yml"
 DEFAULT_CONFIG_DB = "/usr/share/hotstack-sonic/default-config_db.json"
 DEFAULT_FRR_CONF = "/usr/share/hotstack-sonic/default-frr.conf"
+DEFAULT_SONIC_VERSION = "/usr/share/hotstack-sonic/default-sonic_version.yml"
 
 
 class SonicConfig:
@@ -150,6 +153,16 @@ def prepare_sonic_directory(config: SonicConfig) -> None:
         shutil.copy(DEFAULT_FRR_CONF, SONIC_FRR_CONF)
     else:
         LOG.info("No frr.conf found, FRR will use defaults")
+
+    if os.path.exists(SONIC_VERSION_FILE):
+        LOG.info(f"Using sonic_version.yml from: {SONIC_VERSION_FILE}")
+        shutil.copy(SONIC_VERSION_FILE, SONIC_VERSION_YML)
+    elif os.path.exists(DEFAULT_SONIC_VERSION):
+        LOG.info("Using default sonic_version.yml")
+        shutil.copy(DEFAULT_SONIC_VERSION, SONIC_VERSION_YML)
+    else:
+        LOG.error("No sonic_version.yml found - SONiC requires this file")
+        raise FileNotFoundError("sonic_version.yml is required but not found")
 
     LOG.info("SONiC directory prepared successfully")
 

--- a/images/dib/elements/hotstack-sonic-vs/static/usr/share/hotstack-sonic/default-sonic_version.yml
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/share/hotstack-sonic/default-sonic_version.yml
@@ -1,0 +1,9 @@
+---
+build_version: 'SONiC-VS.hotstack'
+debian_version: 'unknown'
+kernel_version: 'unknown'
+asic_type: vs
+commit_id: 'N/A'
+build_date: 'N/A'
+build_number: 0
+built_by: 'hotstack'


### PR DESCRIPTION
The syncd service was failing because sonic-cfggen requires /etc/sonic/sonic_version.yml to be present. Added a default version file and updated start-sonic script to copy it into the container's /var/lib/sonic directory during startup.