### PR TITLE
Update hotstack.mlarge flavor disk size to 60GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ bootstrap variable files.
 ```bash
 openstack flavor create hotstack.small    --public --vcpus  1 --ram  2048 --disk  20
 openstack flavor create hotstack.medium   --public --vcpus  2 --ram  4096 --disk  40
-openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  40
+openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  60
 openstack flavor create hotstack.large    --public --vcpus  4 --ram  8192 --disk  80
 openstack flavor create hotstack.xlarge   --public --vcpus  8 --ram 16384 --disk 160
 openstack flavor create hotstack.xxlarge  --public --vcpus 12 --ram 32768 --disk 160

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -75,7 +75,7 @@ Create flavors sized appropriately for HotStack scenarios:
 ```shell
 openstack flavor create hotstack.small    --public --vcpus  1 --ram  2048 --disk  20
 openstack flavor create hotstack.medium   --public --vcpus  2 --ram  4096 --disk  40
-openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  40
+openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  60
 openstack flavor create hotstack.large    --public --vcpus  4 --ram  8192 --disk  80
 openstack flavor create hotstack.xlarge   --public --vcpus  8 --ram 16384 --disk 160
 openstack flavor create hotstack.xxlarge  --public --vcpus 12 --ram 32768 --disk 160

--- a/devsetup/hotstack-os/scripts/post-setup.py
+++ b/devsetup/hotstack-os/scripts/post-setup.py
@@ -124,7 +124,7 @@ DEFAULT_ADMIN_CLOUD = load_env_var("HOTSTACK_ADMIN_CLOUD", "hotstack-os-admin")
 FLAVORS = [
     {"name": "hotstack.small", "vcpus": 1, "ram": 2048, "disk": 20},
     {"name": "hotstack.medium", "vcpus": 2, "ram": 4096, "disk": 40},
-    {"name": "hotstack.mlarge", "vcpus": 2, "ram": 6144, "disk": 40},
+    {"name": "hotstack.mlarge", "vcpus": 2, "ram": 6144, "disk": 60},
     {"name": "hotstack.large", "vcpus": 4, "ram": 8192, "disk": 80},
     {"name": "hotstack.xlarge", "vcpus": 8, "ram": 16384, "disk": 160},
     {"name": "hotstack.xxlarge", "vcpus": 12, "ram": 32768, "disk": 160},

--- a/docs/deploy_hotstack_on_psi.md
+++ b/docs/deploy_hotstack_on_psi.md
@@ -179,7 +179,7 @@ be created using following commands:
 ```bash
 openstack flavor create hotstack.small    --public --vcpus  1 --ram  2048 --disk  20
 openstack flavor create hotstack.medium   --public --vcpus  2 --ram  4096 --disk  40
-openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  40
+openstack flavor create hotstack.mlarge   --public --vcpus  2 --ram  6144 --disk  60
 openstack flavor create hotstack.large    --public --vcpus  4 --ram  8192 --disk  80
 openstack flavor create hotstack.xlarge   --public --vcpus  8 --ram 16384 --disk 160
 openstack flavor create hotstack.xxlarge  --public --vcpus 12 --ram 32768 --disk 160


### PR DESCRIPTION
Increase the disk size for the hotstack.mlarge flavor from 40GB to 60GB to provide more storage capacity for BMH (BareMetalHost) nodes. This flavor is used by all BMH-based scenarios including sno-bmh-tests, sno-bmh-tests-ipv6, multi-nodeset, and multi-ns.

Changes:
- Updated flavor creation commands in documentation
- Updated FLAVORS specification in post-setup.py script
- All BMH scenarios already configured to use mlarge flavor

Assisted-By: Claude (claude-4.5-sonnet)