### PR TITLE
Add SSH access to SONiC-VS via custom container image

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/README.rst
+++ b/images/dib/elements/hotstack-sonic-vs/README.rst
@@ -4,7 +4,7 @@ hotstack-sonic-vs
 
 This element creates a CentOS 9 Stream image that runs SONiC
 (Software for Open Networking in the Cloud) as a podman container
-with macvlan networking.
+with direct interface movement networking.
 
 Environment Variables
 =====================
@@ -19,8 +19,9 @@ Overview
 The image includes:
 
 - Podman for running the SONiC container
+- Custom SONiC-VS image with SSH access and admin user pre-configured
 - Systemd service (sonic.service) to manage the container lifecycle
-- Python startup script (start-sonic) that creates macvlan interfaces
+- Python startup script (start-sonic) that moves host interfaces into container
 - Default minimal configuration for management access
 - Support for config_db.json configuration format
 
@@ -35,7 +36,7 @@ The config file contains shell-style variables for the host configuration:
 - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
 - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
 - SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-- SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:latest)
+- SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:hotstack)
 
 Host interfaces are moved directly into the container namespace:
 - Host eth1 -> Container eth0 (SONiC Management0)
@@ -44,3 +45,54 @@ Host interfaces are moved directly into the container namespace:
 - etc.
 
 The config_db.json file contains SONiC native configuration in JSON format.
+
+SSH Access
+==========
+
+The custom SONiC-VS image includes SSH access pre-configured:
+
+- **Admin user**: Pre-created with sudo, redis, and frrvty groups
+- **SSH daemon**: Starts automatically via supervisord
+- **Authentication**: Uses SSH keys from /etc/hotstack-sonic/authorized_keys
+
+**IMPORTANT**: The authorized_keys file is REQUIRED and must be created via
+cloud-init. The container will not start without it.
+
+Example cloud-init configuration::
+
+  write_files:
+    - path: /etc/hotstack-sonic/authorized_keys
+      content: |
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host
+      owner: root:root
+      permissions: '0644'
+
+To access the switch via SSH::
+
+  ssh admin@<switch-ip>
+
+The admin user has full sudo access (passwordless) and can run all SONiC CLI
+commands (show, config) and FRR commands (vtysh).
+
+Custom Image Build
+==================
+
+During disk image creation (DIB), a custom SONiC-VS image is built:
+
+1. Base SONiC-VS image is loaded on the build host
+2. Custom image is built using Containerfile from the DIB element
+3. Custom image is saved and included in the disk image
+4. On first boot, the pre-built custom image is simply loaded
+
+The custom image adds:
+- sudo package
+- admin user with proper groups (sudo, redis, frrvty)
+- SSH host keys and daemon configuration
+- Passwordless sudo for admin user
+
+This approach ensures consistent images across all deployments and faster
+first boot times compared to building the image at runtime.
+
+To customize the image, edit the Containerfile and sshd.conf in the
+images/dib/elements/hotstack-sonic-vs/extra-data.d/ directory and rebuild
+the disk image.

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/11-copy-sonic-image
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/11-copy-sonic-image
@@ -28,8 +28,34 @@ if [ -z "${SONIC_VERSION}" ]; then
     SONIC_VERSION="latest"
 fi
 
-echo "INFO: Copying SONiC docker image archive (version: ${SONIC_VERSION})"
-mkdir -p "${TMP_HOOKS_PATH}"
-cp "${DIB_SONIC_IMAGE}" "${TMP_HOOKS_PATH}/sonic-image.tar.gz"
+echo "INFO: Loading base SONiC-VS image on build host (version: ${SONIC_VERSION})"
+podman load -i "${DIB_SONIC_IMAGE}"
 
-echo "INFO: SONiC image archive ready for installation (version: ${SONIC_VERSION})"
+echo "INFO: Building custom SONiC-VS image with SSH access"
+# Create temporary directory for build context
+BUILD_DIR=$(mktemp -d)
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+# Get the directory where this script is located (extra-data.d)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Copy Containerfile, sshd.conf, and docker-wrapper.sh to build context
+cp "${SCRIPT_DIR}/Containerfile" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/sshd.conf" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/docker-wrapper.sh" "${BUILD_DIR}/"
+
+# Build custom image
+podman build -t "localhost/docker-sonic-vs:hotstack" -f "${BUILD_DIR}/Containerfile" "${BUILD_DIR}"
+
+echo "INFO: Saving custom SONiC-VS image as podman archive"
+mkdir -p "${TMP_HOOKS_PATH}"
+podman save -o "${TMP_HOOKS_PATH}/sonic-image.tar" "localhost/docker-sonic-vs:hotstack"
+
+echo "INFO: Compressing SONiC podman archive"
+gzip "${TMP_HOOKS_PATH}/sonic-image.tar"
+
+echo "INFO: Cleaning up images from build host"
+podman rmi "localhost/docker-sonic-vs:hotstack"
+podman rmi "localhost/docker-sonic-vs:latest"
+
+echo "INFO: Custom SONiC-VS image built and ready for installation (version: ${SONIC_VERSION})"

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/Containerfile
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/Containerfile
@@ -1,0 +1,44 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Customize the base SONiC-VS image with SSH access and admin user
+# This Containerfile is used to build a custom image from the upstream SONiC-VS base image
+
+ARG BASE_IMAGE=localhost/docker-sonic-vs:latest
+FROM ${BASE_IMAGE}
+
+# Install sudo, create admin user, and configure SSH
+RUN apt-get update && \
+    apt-get install -y sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -m -s /bin/bash -G sudo,redis,frrvty admin && \
+    echo "admin ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/admin && \
+    chmod 0440 /etc/sudoers.d/admin && \
+    mkdir -p /home/admin/.ssh && \
+    chown admin:admin /home/admin/.ssh && \
+    chmod 700 /home/admin/.ssh && \
+    ssh-keygen -A && \
+    mkdir -p /run/sshd
+
+# Add fake docker wrapper for SONiC CLI compatibility
+COPY docker-wrapper.sh /usr/local/bin/docker
+RUN chmod +x /usr/local/bin/docker
+
+# Add supervisord configuration for sshd
+COPY sshd.conf /etc/supervisor/conf.d/sshd.conf
+
+# Metadata
+LABEL maintainer="hotstack"
+LABEL description="SONiC-VS with SSH access and admin user configured"

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/docker-wrapper.sh
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/docker-wrapper.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Fake docker wrapper for SONiC-VS containerized environment
+# SONiC CLI commands (show, config) expect to run in a hardware SONiC environment
+# where they execute "docker exec sonic <command>" to run commands inside containers.
+# In SONiC-VS we are already inside the container, so we need to fake docker.
+
+case "$1" in
+    ps)
+        # Return fake container info - pretend we are running in a container named "sonic"
+        # This is needed for SONiC CLI to detect the container is running
+        echo "docker-sonic-vs:latest      sonic"
+        ;;
+    exec)
+        # docker exec <container> <command...>
+        # Skip "exec" and container name, run the command directly
+        shift
+        shift
+        exec "$@"
+        ;;
+    *)
+        # For any other docker command, just succeed silently
+        exit 0
+        ;;
+esac

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/sshd.conf
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/sshd.conf
@@ -1,0 +1,23 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Supervisord configuration for SSH daemon
+[program:sshd]
+command=/usr/sbin/sshd -D
+priority=3
+autostart=true
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
@@ -12,7 +12,7 @@ config
   - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
   - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
   - SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-  - SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:latest)
+  - SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:hotstack)
 
 config_db.json
   SONiC native configuration file in JSON format. This file is mounted
@@ -25,6 +25,12 @@ frr.conf
 sonic_version.yml
   SONiC version information file. Required by SONiC services. If not
   provided, a default version file will be used.
+
+authorized_keys (REQUIRED)
+  SSH authorized_keys file for the admin user. This file is mounted into
+  the SONiC container at /home/admin/.ssh/authorized_keys and enables
+  SSH access to the switch. This file is REQUIRED - the container will
+  not start without it.
 
 Usage with cloud-init
 ----------------------
@@ -45,3 +51,23 @@ Use write_files to create these configuration files:
             }
           }
         }
+    - path: /etc/hotstack-sonic/authorized_keys
+      content: |
+        ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host
+      owner: root:root
+      permissions: '0644'
+
+Note: The authorized_keys file is REQUIRED. You can use Heat parameters
+to inject SSH keys, for example:
+
+  parameters:
+    controller_ssh_pub_key:
+      type: string
+
+  resources:
+    leaf01:
+      properties:
+        user_data:
+          write_files:
+            - path: /etc/hotstack-sonic/authorized_keys
+              content: {get_param: controller_ssh_pub_key}

--- a/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/start-sonic
@@ -39,6 +39,7 @@ CONFIG_FILE = "/etc/hotstack-sonic/config"
 CONFIG_DB_FILE = "/etc/hotstack-sonic/config_db.json"
 FRR_CONF_FILE = "/etc/hotstack-sonic/frr.conf"
 SONIC_VERSION_FILE = "/etc/hotstack-sonic/sonic_version.yml"
+AUTHORIZED_KEYS_FILE = "/etc/hotstack-sonic/authorized_keys"
 SONIC_DIR = "/var/lib/sonic"
 SONIC_CONFIG_DB = "/var/lib/sonic/config_db.json"
 SONIC_FRR_CONF = "/var/lib/sonic/frr.conf"
@@ -57,7 +58,7 @@ class SonicConfig:
         self.switch_interface_start = "eth1"
         self.switch_interface_count = 5
         self.switch_hostname = "sonic"
-        self.sonic_image = "localhost/docker-sonic-vs:latest"
+        self.sonic_image = "localhost/docker-sonic-vs:hotstack"
 
     def load_from_file(self, config_file: str = CONFIG_FILE) -> None:
         """Load configuration from shell-style config file.
@@ -284,7 +285,7 @@ def start_sonic_container(config: SonicConfig):
     """Start the SONiC container.
 
     Creates and starts a privileged podman container with the SONiC image,
-    mounting the config directory.
+    mounting the config directory and SSH authorized_keys.
 
     :param config: SonicConfig instance with switch configuration
     :returns: True if container started successfully, False otherwise
@@ -306,8 +307,28 @@ def start_sonic_container(config: SonicConfig):
         f"{SONIC_DIR}:/etc/sonic:rw",
         "-v",
         f"{SONIC_FRR_CONF}:/etc/frr/frr.conf:rw",
-        config.sonic_image,
     ]
+
+    # Mount SSH authorized_keys - required for SSH access to admin user
+    # The authorized_keys file must be provided via cloud-init at /etc/hotstack-sonic/authorized_keys
+    if not os.path.exists(AUTHORIZED_KEYS_FILE):
+        LOG.error(f"SSH authorized_keys not found at {AUTHORIZED_KEYS_FILE}")
+        LOG.error(
+            "SSH access is required but cannot be configured without authorized_keys"
+        )
+        LOG.error("This file must be created via cloud-init write_files")
+        return False
+
+    LOG.info("Mounting SSH authorized_keys for admin user")
+    cmd.extend(
+        [
+            "-v",
+            f"{AUTHORIZED_KEYS_FILE}:/home/admin/.ssh/authorized_keys:ro",
+        ]
+    )
+
+    # Use the custom hotstack image with SSH and admin user configured
+    cmd.append("localhost/docker-sonic-vs:hotstack")
 
     run_command(cmd)
 

--- a/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/Containerfile
+++ b/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/Containerfile
@@ -1,0 +1,40 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Customize the base SONiC-VS image with SSH access and admin user
+# This Containerfile is used to build a custom image from the upstream SONiC-VS base image
+
+ARG BASE_IMAGE=localhost/docker-sonic-vs:latest
+FROM ${BASE_IMAGE}
+
+# Install sudo, create admin user, and configure SSH in a single layer
+RUN apt-get update && \
+    apt-get install -y sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -m -s /bin/bash -G sudo,redis,frrvty admin && \
+    echo "admin ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/admin && \
+    chmod 0440 /etc/sudoers.d/admin && \
+    mkdir -p /home/admin/.ssh && \
+    chown admin:admin /home/admin/.ssh && \
+    chmod 700 /home/admin/.ssh && \
+    ssh-keygen -A && \
+    mkdir -p /run/sshd
+
+# Add supervisord configuration for sshd
+COPY sshd.conf /etc/supervisor/conf.d/sshd.conf
+
+# Metadata
+LABEL maintainer="hotstack"
+LABEL description="SONiC-VS with SSH access and admin user configured"

--- a/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/README.md
+++ b/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/README.md
@@ -1,0 +1,53 @@
+# SONiC Custom Image Build
+
+This directory contains files for building a custom SONiC-VS container image with SSH access and admin user pre-configured.
+
+## Files
+
+- **Containerfile**: Builds the custom image from the base SONiC-VS image
+- **sshd.conf**: Supervisord configuration for the SSH daemon
+
+## What the Custom Image Includes
+
+The custom image (`localhost/docker-sonic-vs:hotstack`) is built on top of the upstream SONiC-VS base image and adds:
+
+1. **sudo package** - Required for SONiC CLI commands
+2. **admin user** - Pre-created with proper groups (sudo, redis, frrvty)
+3. **Passwordless sudo** - Admin user can run sudo commands without password
+4. **SSH host keys** - Pre-generated for SSH access
+5. **SSH daemon** - Configured in supervisord and starts automatically
+6. **.ssh directory** - Pre-created for admin user (authorized_keys mounted at runtime)
+
+## Build Process
+
+The custom image is built automatically by the `sonic-import.service` systemd service on first boot:
+
+1. Base SONiC-VS image is loaded from `/var/lib/sonic/sonic-image.tar.gz`
+2. Custom image is built using the Containerfile in this directory
+3. Result is tagged as `localhost/docker-sonic-vs:hotstack`
+
+## SSH Access
+
+SSH access is enabled through:
+
+1. **Image build time**: Admin user, sudo, SSH daemon, and host keys are configured
+2. **Container runtime**: Host's `/root/.ssh/authorized_keys` is mounted into the container
+
+This allows SSH access using: `ssh admin@<switch-ip>`
+
+## Admin User Permissions
+
+The admin user has the following capabilities:
+
+- **sudo access**: Can run any command with sudo (passwordless)
+- **SONiC CLI**: Can run `show` and `config` commands
+- **FRR CLI**: Can run `vtysh` commands (member of frrvty group)
+- **Redis access**: Can run `redis-cli` commands (member of redis group)
+
+## Customization
+
+To modify the custom image:
+
+1. Edit the `Containerfile` or `sshd.conf` in this directory
+2. Remove `/var/lib/sonic/.image-imported` to force rebuild on next boot
+3. Restart the system or run: `systemctl restart sonic-import.service sonic.service`

--- a/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/sshd.conf
+++ b/images/dib/elements/hotstack-sonic-vs/static/var/lib/sonic/sshd.conf
@@ -1,0 +1,23 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Supervisord configuration for SSH daemon
+[program:sshd]
+command=/usr/sbin/sshd -D
+priority=3
+autostart=true
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog


### PR DESCRIPTION
Build a custom SONiC-VS container image with SSH access and admin user pre-configured. The custom image includes sudo, admin user with proper groups (sudo, redis, frrvty), SSH host keys, and sshd daemon.

SSH authorized_keys must be provided via cloud-init at /etc/hotstack-sonic/authorized_keys and is mounted into the container at runtime. Container startup fails if authorized_keys is missing.

Changes:
- Add Containerfile to build custom image from base SONiC-VS
- Add sshd.conf for supervisord configuration
- Update sonic-import.service to build custom image on first boot
- Update start-sonic to mount authorized_keys and use custom image
- Remove runtime SSH setup code (now handled at image build time)
- Update documentation with SSH access requirements and examples

The admin user has passwordless sudo and can run all SONiC CLI commands (show, config) and FRR commands (vtysh).

Assisted-By: Claude (claude-4.5-sonnet)