### PR TITLE
Migrate SONiC-VS from podman to systemd-nspawn

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/README.rst
+++ b/images/dib/elements/hotstack-sonic-vs/README.rst
@@ -3,8 +3,8 @@ hotstack-sonic-vs
 ==================
 
 This element creates a CentOS 9 Stream image that runs SONiC
-(Software for Open Networking in the Cloud) as a podman container
-with direct interface movement networking.
+(Software for Open Networking in the Cloud) using systemd-nspawn
+with a persistent network namespace.
 
 Environment Variables
 =====================
@@ -18,12 +18,14 @@ Overview
 
 The image includes:
 
-- Podman for running the SONiC container
-- Custom SONiC-VS image with SSH access and admin user pre-configured
+- systemd-nspawn for running the SONiC container
+- Custom SONiC-VS rootfs with SSH access and admin user pre-configured
+- Persistent network namespace that survives container restarts
 - Systemd service (sonic.service) to manage the container lifecycle
-- Python startup script (start-sonic) that moves host interfaces into container
+- Python setup script (setup-sonic) that creates namespace and moves interfaces
 - Default minimal configuration for management access
 - Support for config_db.json configuration format
+- Uses S6000 default hardware configuration (40G ports, 4 lanes per port)
 
 Configuration
 =============
@@ -35,30 +37,95 @@ The config file contains shell-style variables for the host configuration:
 - MGMT_INTERFACE: Host management interface (default: eth0)
 - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
 - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
-- SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-- SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:hotstack)
-
-Host interfaces are moved directly into the container namespace:
-- Host eth1 -> Container eth0 (SONiC Management0)
-- Host eth2 -> Container eth1 (SONiC Ethernet0)
-- Host eth3 -> Container eth2 (SONiC Ethernet1)
+Host interfaces are moved and renamed into a persistent network namespace (sonic-ns)
+before the container starts, ensuring they survive container restarts:
+- Host eth1 -> Namespace eth0 (SONiC management interface)
+- Host eth2 -> Namespace eth1 (first data port)
+- Host eth3 -> Namespace eth2 (second data port)
 - etc.
 
 The config_db.json file contains SONiC native configuration in JSON format.
 
+Interface Mapping
+==================
+
+The setup-sonic script moves and renames host interfaces into the sonic-ns
+namespace. This renaming ensures the management interface is always eth0
+inside the container:
+
+- Host eth1 becomes namespace eth0 (used for SONiC management)
+- Host eth2 becomes namespace eth1 (first data port)
+- Host eth3 becomes namespace eth2 (second data port)
+- etc.
+
+The SONiC container uses the default Force10-S6000 hardware configuration.
+Configure ports in config_db.json using standard SONiC port naming.
+
+Network Namespace Architecture
+================================
+
+The container uses a persistent network namespace (sonic-ns) that survives
+container restarts:
+
+1. **Setup Phase** (before container starts):
+   - Create persistent namespace: /var/run/netns/sonic-ns
+   - Move and rename host interfaces (eth1->eth0, eth2->eth1, etc.) into sonic-ns
+   - Configure management interface IP from config_db.json
+   - Interfaces remain in namespace even if container crashes
+
+2. **Container Start**:
+   - systemd-nspawn joins the sonic-ns namespace
+   - SONiC processes see eth0, eth1, eth2, etc. immediately
+   - No race conditions or timing issues
+
+3. **Container Restart**:
+   - Namespace persists with interfaces intact
+   - Container rejoins same namespace
+   - No interface movement needed
+
+This solves the critical issue where interfaces were lost when the podman
+container restarted, as they were tied to the container's ephemeral namespace.
+
+Management Interface Configuration
+===================================
+
+In hardware SONiC, the ``hostcfgd`` daemon reads the ``MGMT_INTERFACE`` section
+from Redis CONFIG_DB and applies it to ``eth0``. However, ``hostcfgd`` requires
+full systemd and other system services not available in containerized SONiC-VS.
+
+Instead, the ``setup-sonic`` script (which runs on the host before the container
+starts) reads the ``MGMT_INTERFACE`` configuration from ``config_db.json`` and
+applies it directly to ``eth0`` in the ``sonic-ns`` network namespace using
+standard Linux ``ip`` commands.
+
+This approach is cleaner than configuring the IP inside the container because:
+
+- No timing issues - IP is configured before container starts
+- No capability concerns - runs with full host privileges
+- Simpler architecture - all network setup happens in one place
+- Management interface is ready immediately when container starts
+
+Example ``MGMT_INTERFACE`` configuration in ``config_db.json``::
+
+  "MGMT_INTERFACE": {
+    "eth0|192.168.32.113/24": {
+      "gwaddr": "192.168.32.1"
+    }
+  }
+
+The ``setup-sonic`` script extracts this configuration and applies it to ``eth0``
+in the persistent network namespace before ``systemd-nspawn`` starts the container.
+
 SSH Access
 ==========
 
-The custom SONiC-VS image includes SSH access pre-configured:
+The custom SONiC-VS rootfs includes SSH access pre-configured:
 
-- **Admin user**: Pre-created with sudo, redis, and frrvty groups
+- **Admin user**: Pre-created with sudo, redis, and frrvty groups (password: "password")
 - **SSH daemon**: Starts automatically via supervisord
-- **Authentication**: Uses SSH keys from /etc/hotstack-sonic/authorized_keys
+- **Authentication**: Supports both SSH keys and password authentication
 
-**IMPORTANT**: The authorized_keys file is REQUIRED and must be created via
-cloud-init. The container will not start without it.
-
-Example cloud-init configuration::
+Example cloud-init configuration for SSH key authentication::
 
   write_files:
     - path: /etc/hotstack-sonic/authorized_keys
@@ -67,32 +134,95 @@ Example cloud-init configuration::
       owner: root:root
       permissions: '0644'
 
-To access the switch via SSH::
+To access the switch via SSH (using keys or password "password")::
 
   ssh admin@<switch-ip>
 
-The admin user has full sudo access (passwordless) and can run all SONiC CLI
+Or from the host using machinectl::
+
+  machinectl shell sonic
+
+The admin user has full sudo access (password: "password") and can run all SONiC CLI
 commands (show, config) and FRR commands (vtysh).
 
-Custom Image Build
-==================
+Custom Rootfs Build
+===================
 
-During disk image creation (DIB), a custom SONiC-VS image is built:
+During disk image creation (DIB), a custom SONiC-VS rootfs is prepared:
 
-1. Base SONiC-VS image is loaded on the build host
+1. Base SONiC-VS podman image is loaded on the build host
 2. Custom image is built using Containerfile from the DIB element
-3. Custom image is saved and included in the disk image
-4. On first boot, the pre-built custom image is simply loaded
+3. Rootfs is extracted from the custom image during the DIB build
+4. Rootfs tar archive is included in the disk image and extracted to /var/lib/machines/sonic during installation
 
-The custom image adds:
+The custom rootfs adds:
 - sudo package
-- admin user with proper groups (sudo, redis, frrvty)
+- admin user (UID 1000) with proper groups (sudo, redis, frrvty)
 - SSH host keys and daemon configuration
-- Passwordless sudo for admin user
+- Admin user password set to "password" for ML2 driver compatibility
+- Fake docker wrapper for SONiC CLI compatibility
+- FRR daemon support (ospfd, bgpd) with supervisord configurations
 
 This approach ensures consistent images across all deployments and faster
-first boot times compared to building the image at runtime.
+first boot times compared to building at runtime.
 
-To customize the image, edit the Containerfile and sshd.conf in the
+To customize the rootfs, edit the Containerfile in the
 images/dib/elements/hotstack-sonic-vs/extra-data.d/ directory and rebuild
 the disk image.
+
+Startup Sequence
+================
+
+1. **sonic.service ExecStartPre**:
+   - Runs: /usr/local/bin/setup-sonic
+   - Creates persistent network namespace (sonic-ns) with loopback
+   - Moves and renames host interfaces into the namespace
+   - Configures management interface IP from config_db.json
+   - Prepares configuration files (config_db.json, bgpd.conf, ospfd.conf, sonic_version.yml)
+
+2. **sonic.service ExecStart**:
+   - Runs: systemd-nspawn with --network-namespace-path=/var/run/netns/sonic-ns
+   - Container boots and joins the persistent namespace
+   - SONiC's start.sh runs and initializes services
+   - All interfaces are already present (no race conditions)
+
+Troubleshooting
+===============
+
+Check namespace and interfaces::
+
+  # List network namespaces
+  ip netns list
+
+  # Check interfaces in sonic-ns namespace
+  ip netns exec sonic-ns ip link show
+
+  # Check container status
+  machinectl status sonic
+
+  # View container logs
+  journalctl -u sonic.service -f
+
+Access container::
+
+  # Interactive shell
+  machinectl shell sonic
+
+  # Run command
+  machinectl shell sonic /usr/bin/supervisorctl status
+
+Inside container, verify SONiC::
+
+  # Check interfaces
+  ip link show
+
+  # Check SONiC configuration
+  cat /usr/share/sonic/hwsku/lanemap.ini
+  cat /usr/share/sonic/hwsku/port_config.ini
+
+  # Check SONiC services
+  supervisorctl status
+
+  # Access SONiC CLI
+  show interfaces status
+  show ip ospf neighbor

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/11-build-sonic-rootfs
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/11-build-sonic-rootfs
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+SONIC_VERSION=$(echo "${DIB_SONIC_IMAGE:-}" \
+    | xargs basename 2>/dev/null \
+    | sed -n 's/docker-sonic-vs-\?\(.*\)\.gz/\1/p')
+
+if [ -z "${SONIC_VERSION}" ]; then
+    SONIC_VERSION="latest"
+fi
+
+echo "INFO: Loading base SONiC-VS image on build host (version: ${SONIC_VERSION})"
+podman load -i "${DIB_SONIC_IMAGE}"
+
+echo "INFO: Building custom SONiC-VS image with SSH access"
+# Create temporary directory for build context
+BUILD_DIR=$(mktemp -d)
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+# Get the directory where this script is located (extra-data.d)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Copy build files to build context
+cp "${SCRIPT_DIR}/Containerfile" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/container-files/sshd.conf" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/container-files/ospfd.conf" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/container-files/bgpd.conf" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/container-files/rebootbackend.conf" "${BUILD_DIR}/"
+cp "${SCRIPT_DIR}/container-files/docker-wrapper.sh" "${BUILD_DIR}/"
+
+# Build custom image
+podman build -t "localhost/docker-sonic-vs:hotstack" -f "${BUILD_DIR}/Containerfile" "${BUILD_DIR}"
+
+echo "INFO: Extracting SONiC rootfs for systemd-nspawn using podman unshare"
+
+# Use podman unshare to extract with proper UID mapping and permission preservation
+# This runs in a user namespace where we appear as root, preserving all permissions
+podman unshare bash -c "
+    CONTAINER_ID=\$(podman create localhost/docker-sonic-vs:hotstack)
+    MOUNT_POINT=\$(podman mount \$CONTAINER_ID)
+    tar -C \$MOUNT_POINT -cf ${TMP_HOOKS_PATH}/sonic-rootfs.tar .
+    podman unmount \$CONTAINER_ID
+    podman rm \$CONTAINER_ID
+"
+
+echo "INFO: Cleaning up"
+# Force remove any leftover containers first
+podman ps -a --filter ancestor=localhost/docker-sonic-vs:hotstack -q | xargs -r podman rm -f
+podman rmi -f "localhost/docker-sonic-vs:hotstack"
+podman rmi -f "localhost/docker-sonic-vs:latest"
+
+echo "INFO: Custom SONiC-VS rootfs built and ready for installation (version: ${SONIC_VERSION})"

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/Containerfile
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/Containerfile
@@ -19,15 +19,19 @@
 ARG BASE_IMAGE=localhost/docker-sonic-vs:latest
 FROM ${BASE_IMAGE}
 
-# Install sudo, create admin user, and configure SSH
+# Install sudo, create admin user with explicit UID/GID, and configure SSH
+# Using UID/GID 1000 for admin user to ensure consistency
+# Set password to "password" for ML2 driver compatibility (both SSH and sudo)
+# Note: Ownership will be fixed in install.d after tar extraction
 RUN apt-get update && \
     apt-get install -y sudo && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -m -s /bin/bash -G sudo,redis,frrvty admin && \
-    echo "admin ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/admin && \
+    groupadd -g 1000 admin && \
+    useradd -m -u 1000 -g 1000 -s /bin/bash -G sudo,redis,frrvty admin && \
+    echo "admin:password" | chpasswd && \
+    echo "admin ALL=(ALL) ALL" > /etc/sudoers.d/admin && \
     chmod 0440 /etc/sudoers.d/admin && \
     mkdir -p /home/admin/.ssh && \
-    chown admin:admin /home/admin/.ssh && \
     chmod 700 /home/admin/.ssh && \
     ssh-keygen -A && \
     mkdir -p /run/sshd
@@ -36,8 +40,23 @@ RUN apt-get update && \
 COPY docker-wrapper.sh /usr/local/bin/docker
 RUN chmod +x /usr/local/bin/docker
 
-# Add supervisord configuration for sshd
+# Patch start.sh to start FRR daemons when configured
+RUN echo '' >> /usr/bin/start.sh && \
+    echo '# Start ospfd when OSPF is configured in ospfd.conf' >> /usr/bin/start.sh && \
+    echo 'if [ -f /etc/frr/ospfd.conf ] && grep -q "^router ospf" /etc/frr/ospfd.conf; then' >> /usr/bin/start.sh && \
+    echo '    supervisorctl start ospfd' >> /usr/bin/start.sh && \
+    echo 'fi' >> /usr/bin/start.sh && \
+    echo '' >> /usr/bin/start.sh && \
+    echo '# Start bgpd when BGP is configured in bgpd.conf' >> /usr/bin/start.sh && \
+    echo 'if [ -f /etc/frr/bgpd.conf ] && grep -q "^router bgp" /etc/frr/bgpd.conf; then' >> /usr/bin/start.sh && \
+    echo '    supervisorctl start bgpd' >> /usr/bin/start.sh && \
+    echo 'fi' >> /usr/bin/start.sh
+
+# Add supervisord configuration for sshd, ospfd, bgpd, and rebootbackend
 COPY sshd.conf /etc/supervisor/conf.d/sshd.conf
+COPY ospfd.conf /etc/supervisor/conf.d/ospfd.conf
+COPY bgpd.conf /etc/supervisor/conf.d/bgpd.conf
+COPY rebootbackend.conf /etc/supervisor/conf.d/rebootbackend.conf
 
 # Metadata
 LABEL maintainer="hotstack"

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/bgpd.conf
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/bgpd.conf
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #
@@ -14,14 +13,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-set -eu -o pipefail
-
-if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-    set -x
-fi
-
-echo "INFO: Enabling SONiC systemd service..."
-
-systemctl enable sonic.service
-
-echo "INFO: SONiC service enabled successfully"
+# Supervisord configuration for BGP daemon (FRR)
+# Started by start.sh when BGP is configured
+[program:bgpd]
+command=/usr/lib/frr/bgpd -A 127.0.0.1
+priority=5
+autostart=false
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/docker-wrapper.sh
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/docker-wrapper.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Fake docker wrapper for SONiC-VS containerized environment
+# SONiC CLI commands (show, config) expect to run in a hardware SONiC environment
+# where they execute "docker exec sonic <command>" to run commands inside containers.
+# In SONiC-VS we are already inside the container, so we need to fake docker.
+
+case "$1" in
+    ps)
+        # Return fake container info - pretend we are running in a container named "sonic"
+        # This is needed for SONiC CLI to detect the container is running
+        echo "docker-sonic-vs:latest      sonic"
+        ;;
+    exec)
+        # docker exec <container> <command...>
+        # Skip "exec" and container name, run the command directly
+        shift
+        shift
+        exec "$@"
+        ;;
+    *)
+        # For any other docker command, just succeed silently
+        exit 0
+        ;;
+esac

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/ospfd.conf
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/ospfd.conf
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #
@@ -14,14 +13,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-set -eu -o pipefail
-
-if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-    set -x
-fi
-
-echo "INFO: Enabling SONiC systemd service..."
-
-systemctl enable sonic.service
-
-echo "INFO: SONiC service enabled successfully"
+# Supervisord configuration for OSPF daemon (FRR)
+# Started by start.sh when OSPF is configured
+[program:ospfd]
+command=/usr/lib/frr/ospfd -A 127.0.0.1
+priority=5
+autostart=false
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/rebootbackend.conf
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/rebootbackend.conf
@@ -1,0 +1,8 @@
+# Dummy rebootbackend program to satisfy start.sh
+# This service doesn't exist in SONiC-VS but start.sh tries to start it
+[program:rebootbackend]
+command=/bin/sleep infinity
+autostart=false
+autorestart=false
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/sshd.conf
+++ b/images/dib/elements/hotstack-sonic-vs/extra-data.d/container-files/sshd.conf
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright Red Hat, Inc.
 # All Rights Reserved.
 #
@@ -14,14 +13,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-set -eu -o pipefail
-
-if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
-    set -x
-fi
-
-echo "INFO: Enabling SONiC systemd service..."
-
-systemctl enable sonic.service
-
-echo "INFO: SONiC service enabled successfully"
+# Supervisord configuration for SSH daemon
+[program:sshd]
+command=/bin/bash -c "mkdir -p /run/sshd && /usr/sbin/sshd -D"
+priority=3
+autostart=true
+autorestart=true
+stdout_logfile=syslog
+stderr_logfile=syslog

--- a/images/dib/elements/hotstack-sonic-vs/install.d/50-import-sonic-images
+++ b/images/dib/elements/hotstack-sonic-vs/install.d/50-import-sonic-images
@@ -20,11 +20,11 @@ if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
     set -x
 fi
 
-SONIC_IMAGE_PATH="/tmp/in_target.d/sonic-image.tar.gz"
+SONIC_ROOTFS_PATH="/tmp/in_target.d/sonic-rootfs.tar"
 
-if [ ! -f "${SONIC_IMAGE_PATH}" ]; then
-    echo "ERROR: SONiC image file not found in build directory: ${SONIC_IMAGE_PATH}"
-    echo "ERROR: This should have been processed by extra-data.d/11-copy-sonic-image"
+if [ ! -f "${SONIC_ROOTFS_PATH}" ]; then
+    echo "ERROR: SONiC rootfs file not found in build directory: ${SONIC_ROOTFS_PATH}"
+    echo "ERROR: This should have been processed by extra-data.d/11-build-sonic-rootfs"
     exit 1
 fi
 
@@ -36,8 +36,11 @@ if [ -z "${SONIC_VERSION}" ]; then
     SONIC_VERSION="latest"
 fi
 
+echo "INFO: Extracting SONiC rootfs to /var/lib/machines/sonic (version: ${SONIC_VERSION})"
+mkdir -p /var/lib/machines/sonic
+tar -C /var/lib/machines/sonic -xf "${SONIC_ROOTFS_PATH}"
+
 mkdir -p /var/lib/sonic
-cp "${SONIC_IMAGE_PATH}" /var/lib/sonic/sonic-image.tar.gz
 echo "${SONIC_VERSION}" > /var/lib/sonic/sonic-version.txt
 
-echo "INFO: SONiC podman archive installed (version: ${SONIC_VERSION})"
+echo "INFO: SONiC rootfs installed successfully"

--- a/images/dib/elements/hotstack-sonic-vs/package-installs.yaml
+++ b/images/dib/elements/hotstack-sonic-vs/package-installs.yaml
@@ -1,8 +1,7 @@
 ---
 bash-completion:
 iproute:
-nmstate:
-podman:
 python3-jinja2:
+systemd-container:
 tcpdump:
 vim-enhanced:

--- a/images/dib/elements/hotstack-sonic-vs/post-install.d/60-set-permissions
+++ b/images/dib/elements/hotstack-sonic-vs/post-install.d/60-set-permissions
@@ -20,8 +20,7 @@ if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
     set -x
 fi
 
-echo "INFO: Enabling SONiC systemd service..."
+# Ensure setup-sonic script is executable
+chmod +x /usr/local/bin/setup-sonic
 
-systemctl enable sonic.service
-
-echo "INFO: SONiC service enabled successfully"
+echo "INFO: Set executable permission for setup-sonic script"

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
@@ -11,26 +11,35 @@ config
   - MGMT_INTERFACE: Host management interface (default: eth0)
   - SWITCH_INTERFACE_START: First interface to move to container (default: eth1)
   - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
-  - SWITCH_HOSTNAME: SONiC hostname (default: sonic)
-  - SONIC_IMAGE: Podman image tag (default: localhost/docker-sonic-vs:hotstack)
 
-config_db.json
-  SONiC native configuration file in JSON format. This file is mounted
-  into the SONiC container at /etc/sonic/config_db.json.
+config_db.json (REQUIRED)
+  SONiC native configuration file in JSON format. This file is copied
+  to /var/lib/sonic/config_db.json and mounted into the container at
+  /etc/sonic/config_db.json. Must include MGMT_INTERFACE section for
+  management IP configuration.
 
-frr.conf
-  FRRouting configuration file. This file is mounted into the SONiC
-  container at /etc/frr/frr.conf.
+bgpd.conf
+  FRRouting BGP daemon configuration file. This file is copied to
+  /var/lib/sonic/bgpd.conf and mounted into the container at
+  /etc/frr/bgpd.conf. If the file contains "router bgp" configuration,
+  the bgpd daemon will be started automatically.
+
+ospfd.conf
+  FRRouting OSPF daemon configuration file. This file is copied to
+  /var/lib/sonic/ospfd.conf and mounted into the container at
+  /etc/frr/ospfd.conf. If the file contains "router ospf" configuration,
+  the ospfd daemon will be started automatically.
 
 sonic_version.yml
   SONiC version information file. Required by SONiC services. If not
   provided, a default version file will be used.
 
-authorized_keys (REQUIRED)
-  SSH authorized_keys file for the admin user. This file is mounted into
-  the SONiC container at /home/admin/.ssh/authorized_keys and enables
-  SSH access to the switch. This file is REQUIRED - the container will
-  not start without it.
+authorized_keys
+  SSH authorized_keys file for the admin user. This file is copied to
+  /var/lib/sonic/admin_ssh/authorized_keys and mounted into the container
+  at /home/admin/.ssh/authorized_keys. Enables SSH key authentication for
+  the admin user. If not provided, password authentication ("password") can
+  be used instead.
 
 Usage with cloud-init
 ----------------------
@@ -40,8 +49,9 @@ Use write_files to create these configuration files:
   write_files:
     - path: /etc/hotstack-sonic/config
       content: |
-        SWITCH_HOSTNAME=leaf01
         SWITCH_INTERFACE_COUNT=8
+      owner: root:root
+      permissions: '0644'
     - path: /etc/hotstack-sonic/config_db.json
       content: |
         {
@@ -49,16 +59,33 @@ Use write_files to create these configuration files:
             "localhost": {
               "hostname": "leaf01"
             }
+          },
+          "MGMT_INTERFACE": {
+            "eth0|192.168.32.113/24": {
+              "gwaddr": "192.168.32.1"
+            }
           }
         }
+      owner: root:root
+      permissions: '0644'
+    - path: /etc/hotstack-sonic/bgpd.conf
+      content: |
+        # Empty or BGP configuration
+      owner: root:root
+      permissions: '0644'
+    - path: /etc/hotstack-sonic/ospfd.conf
+      content: |
+        # Empty or OSPF configuration
+      owner: root:root
+      permissions: '0644'
     - path: /etc/hotstack-sonic/authorized_keys
       content: |
         ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC... user@host
       owner: root:root
       permissions: '0644'
 
-Note: The authorized_keys file is REQUIRED. You can use Heat parameters
-to inject SSH keys, for example:
+Note: The config_db.json file is REQUIRED and must include a MGMT_INTERFACE
+section. You can use Heat parameters to inject SSH keys, for example:
 
   parameters:
     controller_ssh_pub_key:
@@ -69,5 +96,14 @@ to inject SSH keys, for example:
       properties:
         user_data:
           write_files:
+            - path: /etc/hotstack-sonic/config_db.json
+              content: |
+                {
+                  "MGMT_INTERFACE": {
+                    "eth0|192.168.32.113/24": {
+                      "gwaddr": "192.168.32.1"
+                    }
+                  }
+                }
             - path: /etc/hotstack-sonic/authorized_keys
               content: {get_param: controller_ssh_pub_key}

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic.service
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic.service
@@ -14,20 +14,33 @@
 # under the License.
 
 [Unit]
-Description=SONiC Container Switch
-After=network-online.target sonic-import.service
+Description=SONiC systemd-nspawn Container
+After=network-online.target
 Wants=network-online.target
-Requires=sonic-import.service
-ConditionPathExists=/usr/local/bin/start-sonic
+ConditionPathExists=/usr/local/bin/setup-sonic
+ConditionPathExists=/var/lib/machines/sonic
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStartPre=-/usr/bin/podman stop -t 30 sonic
-ExecStartPre=-/usr/bin/podman rm -f sonic
-ExecStart=/usr/local/bin/start-sonic
-ExecStop=/usr/bin/podman stop -t 30 sonic
-ExecStopPost=/usr/bin/podman rm -f sonic
+Type=exec
+ExecStartPre=/usr/local/bin/setup-sonic
+ExecStart=/usr/bin/systemd-nspawn \
+    --quiet \
+    --keep-unit \
+    --link-journal=try-guest \
+    --network-namespace-path=/var/run/netns/sonic-ns \
+    --directory=/var/lib/machines/sonic \
+    --machine=sonic \
+    --setenv=PLATFORM=x86_64-kvm_x86_64-r0 \
+    --setenv=HWSKU=Force10-S6000 \
+    --capability=CAP_NET_BIND_SERVICE,CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_ADMIN \
+    --bind=/var/lib/sonic:/etc/sonic \
+    --bind=/var/lib/sonic/bgpd.conf:/etc/frr/bgpd.conf \
+    --bind=/var/lib/sonic/ospfd.conf:/etc/frr/ospfd.conf \
+    --bind-ro=/var/lib/sonic/admin_ssh:/home/admin/.ssh \
+    /usr/local/bin/supervisord -c /etc/supervisor/supervisord.conf
+ExecStop=/usr/bin/machinectl poweroff sonic
+KillMode=mixed
+KillSignal=SIGRTMIN+3
 Restart=on-failure
 RestartSec=10
 

--- a/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/setup-sonic
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/setup-sonic
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""
+SONiC systemd-nspawn Setup Script
+
+Prepares the environment for SONiC running in systemd-nspawn:
+  - Creates persistent network namespace with loopback
+  - Moves and renames host interfaces into the namespace
+  - Prepares SONiC configuration files
+"""
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import Tuple
+
+logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
+LOG = logging.getLogger(__name__)
+
+CONFIG_FILE = "/etc/hotstack-sonic/config"
+CONFIG_DB_FILE = "/etc/hotstack-sonic/config_db.json"
+BGPD_CONF_FILE = "/etc/hotstack-sonic/bgpd.conf"
+OSPFD_CONF_FILE = "/etc/hotstack-sonic/ospfd.conf"
+SONIC_VERSION_FILE = "/etc/hotstack-sonic/sonic_version.yml"
+AUTHORIZED_KEYS_FILE = "/etc/hotstack-sonic/authorized_keys"
+SONIC_DIR = "/var/lib/sonic"
+SONIC_CONFIG_DB = "/var/lib/sonic/config_db.json"
+SONIC_BGPD_CONF = "/var/lib/sonic/bgpd.conf"
+SONIC_OSPFD_CONF = "/var/lib/sonic/ospfd.conf"
+SONIC_VERSION_YML = "/var/lib/sonic/sonic_version.yml"
+DEFAULT_CONFIG_DB = "/usr/share/hotstack-sonic/default-config_db.json"
+DEFAULT_SONIC_VERSION = "/usr/share/hotstack-sonic/default-sonic_version.yml"
+NETNS_NAME = "sonic-ns"
+
+
+class SonicConfig:
+    """Configuration for SONiC switch host."""
+
+    def __init__(self):
+        """Initialize configuration with default values."""
+        self.mgmt_interface = "eth0"
+        self.switch_interface_start = "eth1"
+        self.switch_interface_count = 5
+
+    def load_from_file(self, config_file: str = CONFIG_FILE) -> None:
+        """Load configuration from shell-style config file.
+
+        :param config_file: Path to configuration file
+        """
+        if not os.path.exists(config_file):
+            LOG.warning(f"Config file {config_file} not found, using defaults")
+            return
+
+        with open(config_file, "r") as f:
+            content = f.read()
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            if "=" not in line:
+                continue
+
+            key, value = line.split("=", 1)
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+
+            if key == "MGMT_INTERFACE":
+                self.mgmt_interface = value
+            elif key == "SWITCH_INTERFACE_START":
+                self.switch_interface_start = value
+            elif key == "SWITCH_INTERFACE_COUNT":
+                self.switch_interface_count = int(value)
+
+    def log_config(self) -> None:
+        """Log the current configuration."""
+        LOG.info("Configuration:")
+        LOG.info(f"  Management Interface: {self.mgmt_interface}")
+        LOG.info(f"  Switch Interface Start: {self.switch_interface_start}")
+        LOG.info(f"  Switch Interface Count: {self.switch_interface_count}")
+
+
+def run_command(cmd: list, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a shell command and return the result.
+
+    :param cmd: Command and arguments as list
+    :param check: Raise exception on non-zero exit code
+    :return: CompletedProcess instance
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+        return result
+    except subprocess.CalledProcessError as e:
+        if check:
+            LOG.error(f"Command failed: {' '.join(cmd)}")
+            LOG.error(f"Exit code: {e.returncode}")
+            if e.stdout:
+                LOG.error(f"stdout: {e.stdout}")
+            if e.stderr:
+                LOG.error(f"stderr: {e.stderr}")
+            raise
+        return e
+
+
+def run_in_netns(cmd: list, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a command in the sonic network namespace.
+
+    :param cmd: Command and arguments as list
+    :param check: Raise exception on non-zero exit code
+    :return: CompletedProcess instance
+    """
+    return run_command(["ip", "netns", "exec", NETNS_NAME] + cmd, check=check)
+
+
+def parse_interface_name(ifname: str) -> Tuple[str, int]:
+    """Parse interface name into base and number.
+
+    :param ifname: Interface name (e.g., 'eth1')
+    :return: Tuple of (base, number) (e.g., ('eth', 1))
+    """
+    match = re.match(r"([a-zA-Z]+)(\d+)", ifname)
+    if not match:
+        raise ValueError(f"Invalid interface name: {ifname}")
+    return match.group(1), int(match.group(2))
+
+
+def create_network_namespace() -> None:
+    """Create persistent network namespace with loopback configured."""
+    netns_path = f"/var/run/netns/{NETNS_NAME}"
+
+    if not os.path.exists(netns_path):
+        LOG.info(f"Creating persistent network namespace: {NETNS_NAME}")
+        run_command(["ip", "netns", "add", NETNS_NAME])
+    else:
+        LOG.info(f"Network namespace {NETNS_NAME} already exists")
+
+    # Always ensure loopback is up (required for redis and inter-service communication)
+    result = run_in_netns(["ip", "link", "show", "lo"], check=False)
+    if "UP" not in result.stdout:
+        LOG.info(f"Bringing up loopback interface in {NETNS_NAME}")
+        run_in_netns(["ip", "link", "set", "lo", "up"])
+
+
+def move_interfaces_to_namespace(config: SonicConfig) -> None:
+    """Move and rename host interfaces into the persistent namespace.
+
+    Host eth1 -> Container eth0 (management)
+    Host eth2 -> Container eth1 (first data port)
+    Host eth3 -> Container eth2 (second data port)
+    etc.
+
+    :param config: SONiC configuration
+    :raises RuntimeError: If a configured interface doesn't exist
+    """
+    LOG.info("Moving and renaming interfaces into sonic-ns namespace...")
+
+    if_base, if_start_num = parse_interface_name(config.switch_interface_start)
+
+    for i in range(config.switch_interface_count):
+        host_if = f"{if_base}{if_start_num + i}"
+        container_if = f"eth{i}"  # Rename: host eth1->container eth0, eth2->eth1, etc.
+
+        # Check if interface is already in the namespace (with new name)
+        result = run_in_netns(["ip", "link", "show", container_if], check=False)
+        if result.returncode == 0:
+            LOG.info(f"Interface {container_if} already in {NETNS_NAME} namespace")
+            continue
+
+        # Check if host interface exists
+        result = run_command(["ip", "link", "show", host_if], check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"Host interface {host_if} not found - check SWITCH_INTERFACE_START and SWITCH_INTERFACE_COUNT configuration")
+
+        LOG.info(f"Moving {host_if} into {NETNS_NAME} namespace as {container_if}")
+        # Move to namespace
+        run_command(["ip", "link", "set", host_if, "netns", NETNS_NAME])
+
+        # Rename inside the namespace
+        run_in_netns(["ip", "link", "set", host_if, "name", container_if])
+
+        # Bring interface up in the namespace
+        run_in_netns(["ip", "link", "set", container_if, "up"])
+
+
+def configure_management_interface() -> bool:
+    """Configure management interface IP from config_db.json.
+
+    :return: True on success, False on failure
+    """
+    LOG.info("Configuring management interface...")
+
+    try:
+        # Read config_db.json to get MGMT_INTERFACE settings
+        with open(CONFIG_DB_FILE, "r") as f:
+            config_db = json.load(f)
+
+        mgmt_interfaces = config_db.get("MGMT_INTERFACE", {})
+        mgmt_ip = None
+        mgmt_gw = None
+
+        for key, value in mgmt_interfaces.items():
+            if "|" in key and key.startswith("eth0|"):
+                mgmt_ip = key.split("|")[1]
+                mgmt_gw = value.get("gwaddr")
+                break
+
+        if not mgmt_ip:
+            LOG.error("No MGMT_INTERFACE configuration found in config_db.json")
+            return False
+
+        LOG.info(f"Applying management IP {mgmt_ip} to eth0 in {NETNS_NAME}")
+
+        # Check if already configured
+        result = run_in_netns(["ip", "addr", "show", "eth0"], check=False)
+        if result.returncode == 0 and mgmt_ip.split("/")[0] in result.stdout:
+            LOG.info("Management interface already configured")
+            return True
+
+        # Apply IP address
+        result = run_in_netns(["ip", "addr", "add", mgmt_ip, "dev", "eth0"], check=False)
+        if result.returncode != 0 and result.returncode != 2:
+            LOG.error(f"Failed to add IP address: {result.stderr}")
+            return False
+
+        # Apply default gateway if specified
+        if mgmt_gw:
+            LOG.info(f"Adding default route via {mgmt_gw}")
+            result = run_in_netns(["ip", "route", "add", "default", "via", mgmt_gw], check=False)
+            if result.returncode != 0 and "File exists" not in result.stderr:
+                LOG.error(f"Failed to add default route: {result.stderr}")
+                return False
+
+        LOG.info("Management interface configured successfully")
+        return True
+
+    except (IOError, OSError, json.JSONDecodeError, KeyError) as e:
+        LOG.error(f"Failed to configure management interface: {e}")
+        return False
+
+
+def setup_network_namespace(config: SonicConfig) -> bool:
+    """Setup persistent network namespace and move interfaces into it.
+
+    :param config: SONiC configuration
+    :return: True on success, False on failure
+    """
+    LOG.info("Setting up SONiC network namespace")
+
+    # Create namespace with loopback
+    create_network_namespace()
+
+    # Move interfaces
+    move_interfaces_to_namespace(config)
+
+    # Configure management interface IP
+    if not configure_management_interface():
+        return False
+
+    LOG.info("Network namespace setup complete")
+    return True
+
+
+def prepare_config_files():
+    """Prepare SONiC configuration files.
+
+    :return: True on success, False on failure
+    """
+    os.makedirs(SONIC_DIR, exist_ok=True)
+
+    # Required files (with optional defaults)
+    required_files = [
+        (CONFIG_DB_FILE, SONIC_CONFIG_DB, "config_db.json", None),
+        (BGPD_CONF_FILE, SONIC_BGPD_CONF, "bgpd.conf", None),
+        (OSPFD_CONF_FILE, SONIC_OSPFD_CONF, "ospfd.conf", None),
+        (SONIC_VERSION_FILE, SONIC_VERSION_YML, "sonic_version.yml", DEFAULT_SONIC_VERSION),
+    ]
+
+    # Check all required files exist (or have defaults)
+    for src, _, name, default in required_files:
+        if not os.path.exists(src) and default is None:
+            LOG.error(f"Required config file not found: {src}")
+            return False
+
+    # Copy all required files
+    for src, dst, name, default in required_files:
+        actual_src = src if os.path.exists(src) else default
+        LOG.info(f"Using {name} from {actual_src}")
+        with open(actual_src, "r") as src_file:
+            with open(dst, "w") as dst_file:
+                dst_file.write(src_file.read())
+
+    # Copy authorized_keys with correct ownership for admin user (UID 1000)
+    if os.path.exists(AUTHORIZED_KEYS_FILE):
+        admin_ssh_dir = f"{SONIC_DIR}/admin_ssh"
+        os.makedirs(admin_ssh_dir, exist_ok=True)
+        os.chmod(admin_ssh_dir, 0o700)
+        os.chown(admin_ssh_dir, 1000, 1000)
+
+        authorized_keys_dst = f"{admin_ssh_dir}/authorized_keys"
+        LOG.info(f"Copying authorized_keys from {AUTHORIZED_KEYS_FILE}")
+        with open(AUTHORIZED_KEYS_FILE, "r") as src_file:
+            with open(authorized_keys_dst, "w") as dst_file:
+                dst_file.write(src_file.read())
+        os.chmod(authorized_keys_dst, 0o600)
+        os.chown(authorized_keys_dst, 1000, 1000)
+
+    return True
+
+
+def main():
+    """Main entry point - setup network namespace and prepare config files."""
+    config = SonicConfig()
+    config.load_from_file()
+    config.log_config()
+
+    if not prepare_config_files():
+        return 1
+
+    if not setup_network_namespace(config):
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replace podman-based container runtime with systemd-nspawn for improved stability and interface persistence.

- Use systemd-nspawn instead of podman for container runtime
- Create persistent network namespace (sonic-ns) that survives restarts
- Extract rootfs during build instead of loading podman images at runtime
- Add setup-sonic script to configure namespace and interfaces before start
- Configure management interface from config_db.json before container starts
- Add FRR daemon support (ospfd, bgpd) with supervisord configs
- Set admin user password for ML2 driver SSH compatibility

This solves the critical issue where interfaces were lost when the podman container restarted, as they were tied to the container's ephemeral namespace.

Assisted-By: Claude (claude-4.5-sonnet)