### PR TITLE
Use SWITCH_HOSTNAME from config in systemd-nspawn

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/hotstack-sonic/README
@@ -11,6 +11,7 @@ config
   - MGMT_INTERFACE: Host management interface (default: eth0)
   - SWITCH_INTERFACE_START: First interface to move to namespace (default: eth1)
   - SWITCH_INTERFACE_COUNT: Number of interfaces to move (default: 5)
+  - SWITCH_HOSTNAME: Hostname for the SONiC container (default: sonic)
 
 config_db.json (REQUIRED)
   SONiC native configuration file in JSON format. This file is copied

--- a/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic.service
+++ b/images/dib/elements/hotstack-sonic-vs/static/etc/systemd/system/sonic.service
@@ -22,6 +22,8 @@ ConditionPathExists=/var/lib/machines/sonic
 
 [Service]
 Type=exec
+EnvironmentFile=-/etc/hotstack-sonic/config
+Environment=SWITCH_HOSTNAME=sonic
 ExecStartPre=/usr/local/bin/setup-sonic
 ExecStart=/usr/bin/systemd-nspawn \
     --quiet \
@@ -30,6 +32,7 @@ ExecStart=/usr/bin/systemd-nspawn \
     --network-namespace-path=/var/run/netns/sonic-ns \
     --directory=/var/lib/machines/sonic \
     --machine=sonic \
+    --hostname=${SWITCH_HOSTNAME} \
     --setenv=PLATFORM=x86_64-kvm_x86_64-r0 \
     --setenv=HWSKU=Force10-S6000 \
     --capability=CAP_NET_BIND_SERVICE,CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_ADMIN \


### PR DESCRIPTION
The sonic.service now reads SWITCH_HOSTNAME from the config file and passes it to systemd-nspawn via --hostname parameter. This allows each switch instance (spine01, spine02, leaf01, leaf02) to have its proper hostname set inside the container instead of the hardcoded "sonic".

Uses systemd's EnvironmentFile directive to load the config cleanly.

Assisted-By: Claude (claude-4.5-sonnet)