### PR TITLE
Add SONiC VXLAN params to genericswitch config

### DIFF
--- a/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
@@ -151,6 +151,8 @@ ngs_mac_address = 22:57:f8:dd:03:10
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
 ngs_nve_interface = vtep
+vtep_name = vtep
+ngs_bgp_asn = 65001
 
 [genericswitch:leaf02]
 device_type = netmiko_sonic
@@ -162,3 +164,5 @@ ngs_mac_address = 22:57:f8:dd:04:10
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
 ngs_nve_interface = vtep
+vtep_name = vtep
+ngs_bgp_asn = 65001


### PR DESCRIPTION
Adds vtep_name and ngs_bgp_asn required for L2VNI support.

Assisted-By: Claude (claude-4.5-sonnet)