### PR TITLE
Fix VXLAN L2VNI params for SONiC and Arista

### DIFF
--- a/scenarios/networking-lab/devstack-ceos-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-ceos-vxlan/local.conf.j2
@@ -149,7 +149,8 @@ password = admin
 ngs_mac_address = 22:57:f8:dd:03:01
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
-ngs_nve_interface = Vxlan1
+ngs_vxlan_interface = Vxlan1
+ngs_bgp_asn = 65001
 
 [genericswitch:leaf02]
 device_type = netmiko_arista_eos
@@ -159,4 +160,5 @@ password = admin
 ngs_mac_address = 22:57:f8:dd:04:01
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
-ngs_nve_interface = Vxlan1
+ngs_vxlan_interface = Vxlan1
+ngs_bgp_asn = 65001

--- a/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
@@ -150,8 +150,7 @@ secret = password
 ngs_mac_address = 22:57:f8:dd:03:10
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
-ngs_nve_interface = vtep
-vtep_name = vtep
+ngs_vtep_name = vtep
 ngs_bgp_asn = 65001
 
 [genericswitch:leaf02]
@@ -163,6 +162,5 @@ secret = password
 ngs_mac_address = 22:57:f8:dd:04:10
 ngs_disable_inactive_ports = true
 ngs_physical_networks = public
-ngs_nve_interface = vtep
-vtep_name = vtep
+ngs_vtep_name = vtep
 ngs_bgp_asn = 65001


### PR DESCRIPTION
Add ngs_vtep_name and ngs_bgp_asn for SONiC, ngs_vxlan_interface and ngs_bgp_asn for Arista. Remove invalid ngs_nve_interface.

Assisted-By: Claude (claude-4.5-sonnet)