### PR TITLE
Enable IP forwarding in SONiC network namespace

### DIFF
--- a/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/setup-sonic
+++ b/images/dib/elements/hotstack-sonic-vs/static/usr/local/bin/setup-sonic
@@ -163,6 +163,11 @@ def create_network_namespace() -> None:
         LOG.info(f"Bringing up loopback interface in {NETNS_NAME}")
         run_in_netns(["ip", "link", "set", "lo", "up"])
 
+    # Enable IP forwarding (required for routing VXLAN traffic)
+    LOG.info(f"Enabling IP forwarding in {NETNS_NAME}")
+    run_in_netns(["sysctl", "-w", "net.ipv4.ip_forward=1"])
+    run_in_netns(["sysctl", "-w", "net.ipv6.conf.all.forwarding=1"])
+
 
 def move_interfaces_to_namespace(config: SonicConfig) -> None:
     """Move and rename host interfaces into the persistent namespace.


### PR DESCRIPTION
IP forwarding was disabled by default in the sonic-ns network namespace, preventing spine switches from routing VXLAN traffic. Enable both IPv4 and IPv6 forwarding during namespace setup.

Assisted-By: Claude (claude-4.5-sonnet)