### PR TITLE
SONIC: Remove MTU 1442 settings, use default 1500

### DIFF
--- a/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
@@ -1129,14 +1129,14 @@ outputs:
               macaddress: "fa:16:9e:81:f6:20"
             dhcp4: true
             set-name: "enp3s0"
-            mtu: 1442
+            mtu: 1500
           trunk0:
             match:
               macaddress: "fa:16:9e:81:f6:21"
             dhcp4: false
             dhcp6: false
             set-name: trunk0
-            mtu: 1442
+            mtu: 1500
 
   sushy_emulator_uuids:
     description: UUIDs of instances to manage with sushy-tools - RedFish virtual BMC

--- a/scenarios/networking-lab/devstack-sonic-vxlan/leaf01-config_db.json
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/leaf01-config_db.json
@@ -28,13 +28,9 @@
         "Loopback0|10.255.255.3/32": {}
     },
     "INTERFACE": {
-        "Ethernet0": {
-            "mtu": "1442"
-        },
+        "Ethernet0": {},
         "Ethernet0|10.1.1.6/30": {},
-        "Ethernet4": {
-            "mtu": "1442"
-        },
+        "Ethernet4": {},
         "Ethernet4|10.1.1.10/30": {}
     },
     "PORT": {
@@ -54,15 +50,13 @@
             "alias": "fortyGigE0/8",
             "lanes": "33,34,35,36",
             "speed": "40000",
-            "admin_status": "up",
-            "mtu": "1442"
+            "admin_status": "up"
         },
         "Ethernet12": {
             "alias": "fortyGigE0/12",
             "lanes": "37,38,39,40",
             "speed": "40000",
-            "admin_status": "up",
-            "mtu": "1442"
+            "admin_status": "up"
         }
     },
     "VLAN": {},

--- a/scenarios/networking-lab/devstack-sonic-vxlan/leaf02-config_db.json
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/leaf02-config_db.json
@@ -28,13 +28,9 @@
         "Loopback0|10.255.255.4/32": {}
     },
     "INTERFACE": {
-        "Ethernet0": {
-            "mtu": "1442"
-        },
+        "Ethernet0": {},
         "Ethernet0|10.1.1.14/30": {},
-        "Ethernet4": {
-            "mtu": "1442"
-        },
+        "Ethernet4": {},
         "Ethernet4|10.1.1.18/30": {}
     },
     "PORT": {
@@ -54,15 +50,13 @@
             "alias": "fortyGigE0/8",
             "lanes": "33,34,35,36",
             "speed": "40000",
-            "admin_status": "up",
-            "mtu": "1442"
+            "admin_status": "up"
         },
         "Ethernet12": {
             "alias": "fortyGigE0/12",
             "lanes": "37,38,39,40",
             "speed": "40000",
-            "admin_status": "up",
-            "mtu": "1442"
+            "admin_status": "up"
         }
     },
     "VLAN": {},

--- a/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
@@ -8,9 +8,8 @@ SERVICE_PASSWORD=$ADMIN_PASSWORD
 # Service timeouts
 SERVICE_TIMEOUT=120
 
-# MTU - running inside an encapsulated environment, restrict to 1442 on the
-# physical network so VXLAN tenant networks get 1442 - 50 = 1392 effective MTU.
-PUBLIC_BRIDGE_MTU=1442
+# MTU - using default 1500 since undercloud network has MTU 9158
+PUBLIC_BRIDGE_MTU=1500
 
 # Networking
 HOST_IP=192.168.32.20
@@ -118,7 +117,7 @@ disable_service horizon
 
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
-global_physnet_mtu = 1442
+global_physnet_mtu = 1500
 
 [baremetal_agent]
 enable_ha_chassis_group_alignment = False

--- a/scenarios/networking-lab/devstack-sonic-vxlan/spine01-config_db.json
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/spine01-config_db.json
@@ -28,17 +28,11 @@
         "Loopback0|10.255.255.1/32": {}
     },
     "INTERFACE": {
-        "Ethernet0": {
-            "mtu": "1442"
-        },
+        "Ethernet0": {},
         "Ethernet0|10.1.1.1/30": {},
-        "Ethernet4": {
-            "mtu": "1442"
-        },
+        "Ethernet4": {},
         "Ethernet4|10.1.1.5/30": {},
-        "Ethernet8": {
-            "mtu": "1442"
-        },
+        "Ethernet8": {},
         "Ethernet8|10.1.1.13/30": {}
     },
     "PORT": {

--- a/scenarios/networking-lab/devstack-sonic-vxlan/spine02-config_db.json
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/spine02-config_db.json
@@ -28,17 +28,11 @@
         "Loopback0|10.255.255.2/32": {}
     },
     "INTERFACE": {
-        "Ethernet0": {
-            "mtu": "1442"
-        },
+        "Ethernet0": {},
         "Ethernet0|10.1.1.2/30": {},
-        "Ethernet4": {
-            "mtu": "1442"
-        },
+        "Ethernet4": {},
         "Ethernet4|10.1.1.9/30": {},
-        "Ethernet8": {
-            "mtu": "1442"
-        },
+        "Ethernet8": {},
         "Ethernet8|10.1.1.17/30": {}
     },
     "PORT": {


### PR DESCRIPTION
Undercloud network has MTU 9158, providing ample headroom for VXLAN overhead (50 bytes). Using default MTU 1500 eliminates mismatches between physical interfaces, VLANs, and VXLAN tunnels.

Assisted-By: Claude (claude-4.5-sonnet)