### PR TITLE
Add devstack-sonic-vlan scenario

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -346,6 +346,50 @@ make clean
    See `switch-host-scripts/README.md` for details on switch image requirements
    and configuration.
 
+#### Building and uploading the SONiC Virtual Switch image to glance
+
+1. Build the SONiC image (using diskimage-builder):
+
+   ```shell
+   make sonic
+   ```
+
+   This will create a Python virtual environment, install diskimage-builder,
+   build the image using the configuration from `dib/sonic-image.yaml`, and
+   keep it in qcow2 format (default).
+
+2. Upload the SONiC image to Glance:
+
+   ```shell
+   openstack image create hotstack-sonic \
+     --disk-format qcow2 \
+     --file sonic-vs-switch-host.qcow2 \
+     --property hw_firmware_type=uefi \
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
+   ```
+
+   **Note**: The `hw_vif_model=e1000` property is recommended for SONiC switches
+   to avoid virtio checksum offloading issues when connected via OVS/OVN bridge
+   networks.
+
+   **Note**: To convert to raw format (required for Ceph backends):
+
+   ```shell
+   make sonic SONIC_IMAGE_FORMAT=raw
+
+   openstack image create hotstack-sonic \
+     --disk-format raw \
+     --file sonic-vs-switch-host.qcow2 \
+     --property hw_firmware_type=uefi \
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
+   ```
+
+3. See `dib/elements/hotstack-sonic-vs/README.rst` for details on runtime
+   configuration via cloud-init, including network interface setup and SONiC
+   configuration.
+
 #### Building and uploading the cEOS image to glance
 
 1. Build the cEOS image (using diskimage-builder):
@@ -365,8 +409,13 @@ make clean
      --disk-format qcow2 \
      --file ceos-switch-host.qcow2 \
      --property hw_firmware_type=uefi \
-     --property hw_machine_type=q35
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
    ```
+
+   **Note**: The `hw_vif_model=e1000` property is recommended for switch images
+   to avoid virtio checksum offloading issues when connected via OVS/OVN bridge
+   networks.
 
    **Note**: To convert to raw format (required for Ceph backends):
 
@@ -379,7 +428,8 @@ make clean
      --disk-format raw \
      --file ceos-switch-host.qcow2 \
      --property hw_firmware_type=uefi \
-     --property hw_machine_type=q35
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
    ```
 
 3. See `dib/elements/hotstack-ceos/README.rst` for details on runtime

--- a/images/dib/README.md
+++ b/images/dib/README.md
@@ -1,33 +1,53 @@
 # Diskimage-builder (DIB) Files
 
-This directory contains all files related to building the HotStack controller image using diskimage-builder (DIB).
+This directory contains all files related to building HotStack images using diskimage-builder (DIB).
+
+## Available Images
+
+- **hotstack-controller** - Controller node image with dnsmasq, httpd, and supporting services
+- **hotstack-sonic-vs** - SONiC Virtual Switch image for network lab scenarios
+- **hotstack-ceos** - Arista cEOS switch image for network lab scenarios
+- **hotstack-microshift** - MicroShift (lightweight OpenShift) image
 
 ## Contents
 
-- `controller-image.yaml` - DIB configuration file that defines the controller image build
-- `elements/` - Custom DIB elements for HotStack
-  - `hotstack-controller/` - Element that installs packages and configures the controller node
-- `controller.d/` - DIB manifests directory
-  - `dib-manifests/` - Contains DIB arguments and environment configuration
+- `*.yaml` - DIB configuration files that define image builds
+- `elements/` - Custom DIB elements for HotStack images
+  - `hotstack-controller/` - Controller node element
+  - `hotstack-sonic-vs/` - SONiC Virtual Switch element
+  - `hotstack-ceos/` - Arista cEOS element
+  - `hotstack-microshift/` - MicroShift element
+- `*.d/` - DIB manifests directories containing build arguments and environment configuration
 
-## Building the Controller Image
+## Building Images
 
-The controller image is built using the parent Makefile:
+Images are built using the parent Makefile:
 
 ```bash
 cd ..
+
+# Build controller image
 make controller
+
+# Build SONiC Virtual Switch image
+make sonic
+
+# Build cEOS image
+make ceos
+
+# Build MicroShift image
+make microshift
 ```
 
 This will:
 1. Create a Python virtual environment with diskimage-builder
-2. Build the image using the configuration from `controller-image.yaml`
-3. Apply the custom `hotstack-controller` element from `elements/`
+2. Build the image using the configuration from the respective YAML file
+3. Apply the custom element from `elements/`
 4. Convert the image to the desired format (raw or qcow2)
 
 ## Custom Elements
 
-See `elements/README.md` for information about creating and using custom DIB elements.
+See `elements/README.md` for information about creating and using custom DIB elements. Each element has its own README with specific documentation.
 
 ## References
 

--- a/scenarios/networking-lab/devstack-sonic-vlan/README.md
+++ b/scenarios/networking-lab/devstack-sonic-vlan/README.md
@@ -1,0 +1,30 @@
+# Devstack with SONiC VLAN Trunking
+
+VLAN-only networking lab: 1 SONiC switch, 1 Devstack, 2 Ironic nodes, 1 controller.
+
+## Topology
+
+![Topology Diagram](topology-diagram.svg)
+
+Management: `192.168.32.0/24` | VLANs: 100-105 | MTU: 1500
+
+## Deployment
+
+Required images: `hotstack-controller`, `hotstack-sonic-vs`, `ubuntu-noble-server`, `CentOS-Stream-GenericCloud-9`
+
+```bash
+ansible-playbook -e @scenarios/networking-lab/devstack-sonic-vlan/bootstrap_vars.yml \
+  -e os_cloud=<cloud> bootstrap_devstack.yml
+```
+
+## Accessing
+
+Access the switch and devstack nodes via SSH from the controller.
+
+```bash
+# Switch
+ssh admin@switch.stack.lab
+
+# Devstack
+ssh stack@devstack.stack.lab
+```

--- a/scenarios/networking-lab/devstack-sonic-vlan/TROUBLESHOOTING.md
+++ b/scenarios/networking-lab/devstack-sonic-vlan/TROUBLESHOOTING.md
@@ -1,0 +1,87 @@
+# Troubleshooting Network Connectivity
+
+## Access Methods
+
+- **SONiC Switch Container**: `ssh admin@switch.stack.lab` (password: `password`)
+- **Switch Container Host**: `ssh zuul@switch-host.stack.lab`
+- **Devstack**: `ssh stack@devstack.stack.lab`
+
+## Verify Network Topology
+
+### SONiC Switch VLAN Configuration
+```bash
+# Check VLAN configuration
+show vlan config
+
+# Check interface status
+ip link show | grep -E "Ethernet0|Ethernet4|Ethernet8|Vlan"
+```
+
+### Devstack VLAN Interfaces
+```bash
+# Check trunk and bridge interfaces
+ip link show | grep -E "trunk0|br-ex"
+```
+
+## Check Interface Statistics
+
+### On SONiC Switch
+```bash
+# Check baremetal-facing ports
+ip -s link show Ethernet4  # ironic0
+ip -s link show Ethernet8  # ironic1
+
+# Check trunk to devstack
+ip -s link show Ethernet0
+
+# Check bridge and VLAN interfaces
+ip -s link show Bridge
+ip -s link show Vlan103
+ip -s link show Vlan104
+ip -s link show Vlan105
+
+# Look for:
+# - RX/TX errors
+# - RX/TX dropped packets
+# - Collisions
+```
+
+### On Devstack
+```bash
+# Check trunk interface
+ip -s link show trunk0
+
+# Check bridge interfaces
+ip -s link show br-ex
+ip -s link show br-ex.103
+
+# Look for dropped or error counters
+```
+
+## Capture Network Traffic
+
+### Basic Packet Capture
+
+**On Devstack:**
+```bash
+# Watch traffic on VLAN 103
+sudo tcpdump -i trunk0 -evnn vlan 103
+
+# Filter by port (e.g., Ironic API on port 80)
+sudo tcpdump -i trunk0 -evnn vlan 103 and port 80
+
+# More verbose output with packet contents
+sudo tcpdump -i trunk0 -evvvnXX vlan 103
+```
+
+**On SONiC Switch:**
+```bash
+# Capture on baremetal-facing port
+sudo tcpdump -i Ethernet4 -evnn
+
+# Capture on trunk to devstack
+sudo tcpdump -i Ethernet0 -evnn vlan 103
+
+# Capture on bridge with VLAN filter
+sudo tcpdump -i Bridge -evnn vlan 103
+```

--- a/scenarios/networking-lab/devstack-sonic-vlan/automation-vars.yml
+++ b/scenarios/networking-lab/devstack-sonic-vlan/automation-vars.yml
@@ -1,0 +1,65 @@
+---
+stages:
+  - name: Enroll nodes in devstack ironic
+    documentation: >-
+      Registers physical baremetal nodes with the Ironic service in the DevStack
+      deployment using the node definitions from ironic_nodes.yaml. This creates
+      Ironic node records with BMC access credentials, hardware profiles, and port
+      configurations for networking-generic-switch integration.
+    shell: |
+      set -xe -o pipefail
+
+      NODES_FILE=/home/zuul/data/ironic_nodes.yaml
+
+      # Enroll the nodes
+      openstack --os-cloud devstack-admin baremetal create "$NODES_FILE"
+
+      echo "Nodes enrolled successfully"
+      openstack --os-cloud devstack-admin baremetal node list
+
+  - name: Wait for ironic nodes to reach enroll state
+    documentation: >-
+      Monitors node state transition to 'enroll' status, indicating that Ironic
+      has successfully registered the nodes and validated basic BMC connectivity.
+      This is the first state in the baremetal provisioning lifecycle.
+    shell: |
+      set -xe -o pipefail
+
+      counter=0
+      max_retries=60
+      sleep_interval=5
+
+      echo "Waiting for all nodes to reach 'enroll' state..."
+
+      until ! openstack --os-cloud devstack-admin baremetal node list -f value -c "Provisioning State" | grep -v "enroll"; do
+        ((counter++))
+        if (( counter > max_retries )); then
+          echo "ERROR: Timeout waiting for nodes to reach enroll state"
+          openstack --os-cloud devstack-admin baremetal node list
+          exit 1
+        fi
+        echo "Attempt $counter/$max_retries - waiting ${sleep_interval}s..."
+        sleep ${sleep_interval}
+      done
+
+      echo "All nodes successfully reached enroll state"
+      openstack --os-cloud devstack-admin baremetal node list
+
+  - name: Manage nodes
+    documentation: >-
+      Transitions nodes from 'enroll' to 'manageable' state. This validates
+      basic hardware connectivity and prepares nodes for further operations.
+    shell: |
+      set -x -o pipefail
+
+      # Get list of node UUIDs
+      node_uuids=$(openstack --os-cloud devstack-admin baremetal node list -f value -c UUID)
+
+      # Manage each node with --wait (300 second timeout)
+      for uuid in $node_uuids; do
+        echo "Managing node: $uuid"
+        openstack --os-cloud devstack-admin baremetal node manage --wait 300 $uuid
+      done
+
+      echo "All nodes successfully reached manageable state"
+      openstack --os-cloud devstack-admin baremetal node list

--- a/scenarios/networking-lab/devstack-sonic-vlan/bootstrap_vars.yml
+++ b/scenarios/networking-lab/devstack-sonic-vlan/bootstrap_vars.yml
@@ -1,0 +1,46 @@
+---
+# Bootstrap configuration for devstack-sonic-vlan scenario
+
+# OpenStack cloud configuration
+os_cloud: default
+os_floating_network: public
+os_router_external_network: public
+
+# Scenario configuration
+scenario: devstack-sonic-vlan
+scenario_dir: scenarios/networking-lab
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
+
+# DNS and NTP
+ntp_servers: []
+dns_servers:
+  - 8.8.8.8
+  - 8.8.4.4
+
+# Stack naming
+stack_name: "hs-{{ scenario | replace('/', '-') }}-{{ zuul.build[:8] | default('no-zuul') }}"
+
+# Stack parameters
+stack_parameters:
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_pub_key | default('') }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  devstack_params:
+    image: ubuntu-noble-server
+    flavor: hotstack.large
+  switch_params:
+    image: hotstack-sonic
+    flavor: hotstack.medium
+  ironic_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.medium
+
+# Controller role configuration
+controller_install_openstack_client: true

--- a/scenarios/networking-lab/devstack-sonic-vlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-sonic-vlan/heat_template.yaml
@@ -2,8 +2,8 @@
 heat_template_version: rocky
 
 description: >
-  Heat template for networking lab with spine-and-leaf Arista cEOS setup.
-  Includes 4 switches (spine01, spine02, leaf01, leaf02), 1 devstack node, and 2 ironic nodes.
+  Heat template for networking lab with single SONiC switch using simple VLAN trunking (no VXLAN).
+  Includes 1 switch, 1 devstack node, and 2 ironic nodes.
 
 parameters:
   dns_servers:
@@ -42,12 +42,11 @@ parameters:
     type: json
     default:
       image: CentOS-Stream-GenericCloud-9
-      cd_image: sushy-tools-blank-image
       flavor: hotstack.medium
   switch_params:
     type: json
     default:
-      image: hotstack-ceos
+      image: hotstack-sonic
       flavor: hotstack.medium
   cdrom_disk_bus:
     type: string
@@ -71,40 +70,7 @@ resources:
       port_security_enabled: false
       value_specs: {get_param: net_value_specs}
 
-  # Spine switch interconnect
-  spine-link-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
-  # Leaf to spine links
-  leaf01-spine01-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
-  leaf01-spine02-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
-  leaf02-spine01-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
-  leaf02-spine02-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
   # Simple bridge networks for server attachments
-  # These are just L2 connectivity - VLANs and configuration managed by ML2
   devstack-br-net:
     type: OS::Neutron::Net
     properties:
@@ -123,15 +89,7 @@ resources:
       port_security_enabled: false
       value_specs: {get_param: net_value_specs}
 
-  # Trunk network for leaf01 switch
-  leaf01-trunk-net:
-    type: OS::Neutron::Net
-    properties:
-      port_security_enabled: false
-      value_specs: {get_param: net_value_specs}
-
-  # Shared VLAN networks for physical network connectivity
-  public-vlan100:
+  trunk-net:
     type: OS::Neutron::Net
     properties:
       port_security_enabled: false
@@ -168,51 +126,6 @@ resources:
       dns_nameservers:
         - 192.168.32.254
 
-  spine-link-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: spine-link-net}
-      ip_version: 4
-      cidr: 10.1.1.0/30
-      enable_dhcp: false
-      gateway_ip: null
-
-  leaf01-spine01-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: leaf01-spine01-net}
-      ip_version: 4
-      cidr: 10.1.1.4/30
-      enable_dhcp: false
-      gateway_ip: null
-
-  leaf01-spine02-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: leaf01-spine02-net}
-      ip_version: 4
-      cidr: 10.1.1.8/30
-      enable_dhcp: false
-      gateway_ip: null
-
-  leaf02-spine01-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: leaf02-spine01-net}
-      ip_version: 4
-      cidr: 10.1.1.12/30
-      enable_dhcp: false
-      gateway_ip: null
-
-  leaf02-spine02-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: leaf02-spine02-net}
-      ip_version: 4
-      cidr: 10.1.1.16/30
-      enable_dhcp: false
-      gateway_ip: null
-
   devstack-br-subnet:
     type: OS::Neutron::Subnet
     properties:
@@ -240,25 +153,14 @@ resources:
       enable_dhcp: false
       gateway_ip: null
 
-  # Leaf01 trunk subnet
-  leaf01-trunk-subnet:
+  trunk-subnet:
     type: OS::Neutron::Subnet
     properties:
-      network: {get_resource: leaf01-trunk-net}
+      network: {get_resource: trunk-net}
       ip_version: 4
-      cidr: 172.20.20.0/24
+      cidr: 172.20.2.0/24
       enable_dhcp: false
       gateway_ip: null
-
-  # Shared VLAN subnets
-  public-vlan100-subnet:
-    type: OS::Neutron::Subnet
-    properties:
-      network: {get_resource: public-vlan100}
-      ip_version: 4
-      cidr: 172.20.0.0/24
-      gateway_ip: 172.20.0.1
-      enable_dhcp: false
 
   tenant-vlan103-subnet:
     type: OS::Neutron::Subnet
@@ -266,8 +168,8 @@ resources:
       network: {get_resource: tenant-vlan103}
       ip_version: 4
       cidr: 172.20.3.0/24
-      gateway_ip: null
       enable_dhcp: false
+      gateway_ip: null
 
   tenant-vlan104-subnet:
     type: OS::Neutron::Subnet
@@ -275,8 +177,8 @@ resources:
       network: {get_resource: tenant-vlan104}
       ip_version: 4
       cidr: 172.20.4.0/24
-      gateway_ip: null
       enable_dhcp: false
+      gateway_ip: null
 
   tenant-vlan105-subnet:
     type: OS::Neutron::Subnet
@@ -284,8 +186,8 @@ resources:
       network: {get_resource: tenant-vlan105}
       ip_version: 4
       cidr: 172.20.5.0/24
-      gateway_ip: null
       enable_dhcp: false
+      gateway_ip: null
 
   #
   # Routers
@@ -347,25 +249,13 @@ resources:
                 template: |
                   # Host records
                   host-record=controller-0.stack.lab,$controller0
-                  host-record=spine01-host.stack.lab,$spine01_host
-                  host-record=spine01.stack.lab,$spine01
-                  host-record=spine02-host.stack.lab,$spine02_host
-                  host-record=spine02.stack.lab,$spine02
-                  host-record=leaf01-host.stack.lab,$leaf01_host
-                  host-record=leaf01.stack.lab,$leaf01
-                  host-record=leaf02-host.stack.lab,$leaf02_host
-                  host-record=leaf02.stack.lab,$leaf02
+                  host-record=switch-host.stack.lab,$switch_host
+                  host-record=switch.stack.lab,$switch
                   host-record=devstack.stack.lab,$devstack
                 params:
                   $controller0: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
-                  $spine01_host: {get_attr: [spine01-machine-port, fixed_ips, 0, ip_address]}
-                  $spine01: {get_attr: [spine01-switch-mgmt-port, fixed_ips, 0, ip_address]}
-                  $spine02_host: {get_attr: [spine02-machine-port, fixed_ips, 0, ip_address]}
-                  $spine02: {get_attr: [spine02-switch-mgmt-port, fixed_ips, 0, ip_address]}
-                  $leaf01_host: {get_attr: [leaf01-machine-port, fixed_ips, 0, ip_address]}
-                  $leaf01: {get_attr: [leaf01-switch-mgmt-port, fixed_ips, 0, ip_address]}
-                  $leaf02_host: {get_attr: [leaf02-machine-port, fixed_ips, 0, ip_address]}
-                  $leaf02: {get_attr: [leaf02-switch-mgmt-port, fixed_ips, 0, ip_address]}
+                  $switch_host: {get_attr: [switch-machine-port, fixed_ips, 0, ip_address]}
+                  $switch: {get_attr: [switch-switch-mgmt-port, fixed_ips, 0, ip_address]}
                   $devstack: {get_attr: [devstack-machine-port, fixed_ips, 0, ip_address]}
             owner: root:dnsmasq
           - path: /etc/resolv.conf
@@ -384,6 +274,9 @@ resources:
       cloud_config:
         runcmd:
           - ['setenforce', 'permissive']
+          - ['sed', '-i', 's/Listen 80/Listen 8081/g', '/etc/httpd/conf/httpd.conf']
+          - ['systemctl', 'enable', 'httpd.service']
+          - ['systemctl', 'start', 'httpd.service']
           - ['systemctl', 'enable', 'dnsmasq.service']
           - ['systemctl', 'start', 'dnsmasq.service']
 
@@ -421,16 +314,14 @@ resources:
       user_data: {get_resource: controller-init}
 
   #
-  # Spine Switches
+  # SONiC Switch
   #
-
-  # Spine01 Switch
-  spine01-init:
+  switch-init:
     type: OS::Heat::CloudConfig
     properties:
       cloud_config:
-        hostname: spine01
-        fqdn: spine01.stack.lab
+        hostname: switch
+        fqdn: switch.stack.lab
         users:
           - default
           - name: zuul
@@ -440,23 +331,41 @@ resources:
               - {get_param: controller_ssh_pub_key}
               - {get_param: dataplane_ssh_pub_key}
         write_files:
-          - path: /etc/hotstack-ceos/config
+          - path: /etc/hotstack-sonic/config
             content: |
               MGMT_INTERFACE=eth0
               SWITCH_INTERFACE_START=eth1
               SWITCH_INTERFACE_COUNT=4
-              SWITCH_HOSTNAME=spine01
-              CEOS_IMAGE=localhost/ceos:latest
+              SWITCH_HOSTNAME=switch
             owner: root:root
             permissions: '0644'
-          - path: /etc/hotstack-ceos/startup-config
-            content: {get_file: spine01-startup.cfg}
+          - path: /etc/hotstack-sonic/config_db.json
+            content: {get_file: switch-config_db.json}
+            owner: root:root
+            permissions: '0644'
+          - path: /etc/hotstack-sonic/bgpd.conf
+            content: {get_file: switch-bgpd.conf}
+            owner: root:root
+            permissions: '0644'
+          - path: /etc/hotstack-sonic/ospfd.conf
+            content: {get_file: switch-ospfd.conf}
+            owner: root:root
+            permissions: '0644'
+          - path: /etc/hotstack-sonic/authorized_keys
+            content:
+              str_replace:
+                template: |
+                  $CONTROLLER_KEY
+                  $DATAPLANE_KEY
+                params:
+                  $CONTROLLER_KEY: {get_param: controller_ssh_pub_key}
+                  $DATAPLANE_KEY: {get_param: dataplane_ssh_pub_key}
             owner: root:root
             permissions: '0644'
         runcmd:
-          - systemctl start ceos.service
+          - systemctl start sonic.service
 
-  spine01-machine-port:
+  switch-machine-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
@@ -465,7 +374,7 @@ resources:
       fixed_ips:
         - ip_address: 192.168.32.11
 
-  spine01-switch-mgmt-port:
+  switch-switch-mgmt-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: machine-net}
@@ -474,366 +383,78 @@ resources:
       fixed_ips:
         - ip_address: 192.168.32.111
 
-  spine01-spine-link-port:
+  switch-trunk-parent-port:
     type: OS::Neutron::Port
     properties:
-      network: {get_resource: spine-link-net}
+      network: {get_resource: trunk-net}
       port_security_enabled: false
       mac_address: "22:57:f8:dd:01:02"
 
-  spine01-leaf01-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf01-spine01-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:01:04"
-
-  spine01-leaf02-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf02-spine01-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:01:05"
-
-  spine01:
-    type: OS::Nova::Server
-    properties:
-      image: {get_param: [switch_params, image]}
-      flavor: {get_param: [switch_params, flavor]}
-      config_drive: false
-      networks:
-        - port: {get_resource: spine01-machine-port}
-        - port: {get_resource: spine01-switch-mgmt-port}
-        - port: {get_resource: spine01-spine-link-port}
-        - port: {get_resource: spine01-leaf01-port}
-        - port: {get_resource: spine01-leaf02-port}
-      user_data_format: RAW
-      user_data: {get_resource: spine01-init}
-
-  # Spine02 Switch
-  spine02-init:
-    type: OS::Heat::CloudConfig
-    properties:
-      cloud_config:
-        hostname: spine02
-        fqdn: spine02.stack.lab
-        users:
-          - default
-          - name: zuul
-            gecos: "Zuul user"
-            sudo: ALL=(ALL) NOPASSWD:ALL
-            ssh_authorized_keys:
-              - {get_param: controller_ssh_pub_key}
-              - {get_param: dataplane_ssh_pub_key}
-        write_files:
-          - path: /etc/hotstack-ceos/config
-            content: |
-              MGMT_INTERFACE=eth0
-              SWITCH_INTERFACE_START=eth1
-              SWITCH_INTERFACE_COUNT=4
-              SWITCH_HOSTNAME=spine02
-              CEOS_IMAGE=localhost/ceos:latest
-            owner: root:root
-            permissions: '0644'
-          - path: /etc/hotstack-ceos/startup-config
-            content: {get_file: spine02-startup.cfg}
-            owner: root:root
-            permissions: '0644'
-        runcmd:
-          - systemctl start ceos.service
-
-  spine02-machine-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:02:01"
-      fixed_ips:
-        - ip_address: 192.168.32.12
-
-  spine02-switch-mgmt-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:02:10"
-      fixed_ips:
-        - ip_address: 192.168.32.112
-
-  spine02-spine-link-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: spine-link-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:02:02"
-
-  spine02-leaf01-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf01-spine02-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:02:04"
-
-  spine02-leaf02-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf02-spine02-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:02:05"
-
-  spine02:
-    type: OS::Nova::Server
-    properties:
-      image: {get_param: [switch_params, image]}
-      flavor: {get_param: [switch_params, flavor]}
-      config_drive: false
-      networks:
-        - port: {get_resource: spine02-machine-port}
-        - port: {get_resource: spine02-switch-mgmt-port}
-        - port: {get_resource: spine02-spine-link-port}
-        - port: {get_resource: spine02-leaf01-port}
-        - port: {get_resource: spine02-leaf02-port}
-      user_data_format: RAW
-      user_data: {get_resource: spine02-init}
-
-  #
-  # Leaf Switches
-  #
-
-  # Leaf01 Switch
-  leaf01-init:
-    type: OS::Heat::CloudConfig
-    properties:
-      cloud_config:
-        hostname: leaf01
-        fqdn: leaf01.stack.lab
-        users:
-          - default
-          - name: zuul
-            gecos: "Zuul user"
-            sudo: ALL=(ALL) NOPASSWD:ALL
-            ssh_authorized_keys:
-              - {get_param: controller_ssh_pub_key}
-              - {get_param: dataplane_ssh_pub_key}
-        write_files:
-          - path: /etc/hotstack-ceos/config
-            content: |
-              MGMT_INTERFACE=eth0
-              SWITCH_INTERFACE_START=eth1
-              SWITCH_INTERFACE_COUNT=5
-              SWITCH_HOSTNAME=leaf01
-              CEOS_IMAGE=localhost/ceos:latest
-            owner: root:root
-            permissions: '0644'
-          - path: /etc/hotstack-ceos/startup-config
-            content: {get_file: leaf01-startup.cfg}
-            owner: root:root
-            permissions: '0644'
-        runcmd:
-          - systemctl start ceos.service
-
-  leaf01-machine-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:01"
-      fixed_ips:
-        - ip_address: 192.168.32.13
-
-  leaf01-switch-mgmt-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:10"
-      fixed_ips:
-        - ip_address: 192.168.32.113
-
-  leaf01-spine01-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf01-spine01-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:02"
-
-  leaf01-spine02-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf01-spine02-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:04"
-
-  leaf01-devstack-br-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: devstack-br-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:06"
-
-  leaf01-trunk-parent-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf01-trunk-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:05"
-
-  leaf01-trunk-public-vlan100-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: public-vlan100}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:07"
-
-  leaf01-trunk-tenant-vlan103-port:
+  switch-trunk-tenant-vlan103-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan103}
       port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:08"
+      mac_address: "22:57:f8:dd:01:03"
 
-  leaf01-trunk-tenant-vlan104-port:
+  switch-trunk-tenant-vlan104-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan104}
       port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:09"
+      mac_address: "22:57:f8:dd:01:04"
 
-  leaf01-trunk-tenant-vlan105-port:
+  switch-trunk-tenant-vlan105-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan105}
       port_security_enabled: false
-      mac_address: "22:57:f8:dd:03:0a"
+      mac_address: "22:57:f8:dd:01:05"
 
-  leaf01-trunk:
+  switch-trunk:
     type: OS::Neutron::Trunk
     properties:
-      port: {get_resource: leaf01-trunk-parent-port}
+      port: {get_resource: switch-trunk-parent-port}
       sub_ports:
-        - port: {get_resource: leaf01-trunk-public-vlan100-port}
-          segmentation_id: 100
-          segmentation_type: vlan
-        - port: {get_resource: leaf01-trunk-tenant-vlan103-port}
+        - port: {get_resource: switch-trunk-tenant-vlan103-port}
           segmentation_id: 103
           segmentation_type: vlan
-        - port: {get_resource: leaf01-trunk-tenant-vlan104-port}
+        - port: {get_resource: switch-trunk-tenant-vlan104-port}
           segmentation_id: 104
           segmentation_type: vlan
-        - port: {get_resource: leaf01-trunk-tenant-vlan105-port}
+        - port: {get_resource: switch-trunk-tenant-vlan105-port}
           segmentation_id: 105
           segmentation_type: vlan
 
-  leaf02-ironic0-br-port:
+  switch-ironic0-br-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:05"
+      mac_address: "22:57:f8:dd:01:06"
 
-  leaf01:
-    type: OS::Nova::Server
-    depends_on: leaf01-trunk
-    properties:
-      image: {get_param: [switch_params, image]}
-      flavor: {get_param: [switch_params, flavor]}
-      config_drive: false
-      networks:
-        - port: {get_resource: leaf01-machine-port}
-        - port: {get_resource: leaf01-switch-mgmt-port}
-        - port: {get_resource: leaf01-spine01-port}
-        - port: {get_resource: leaf01-spine02-port}
-        - port: {get_attr: [leaf01-trunk, port_id]}
-        - port: {get_resource: leaf01-devstack-br-port}
-      user_data_format: RAW
-      user_data: {get_resource: leaf01-init}
-
-  # Leaf02 Switch
-  leaf02-init:
-    type: OS::Heat::CloudConfig
-    properties:
-      cloud_config:
-        hostname: leaf02
-        fqdn: leaf02.stack.lab
-        users:
-          - default
-          - name: zuul
-            gecos: "Zuul user"
-            sudo: ALL=(ALL) NOPASSWD:ALL
-            ssh_authorized_keys:
-              - {get_param: controller_ssh_pub_key}
-              - {get_param: dataplane_ssh_pub_key}
-        write_files:
-          - path: /etc/hotstack-ceos/config
-            content: |
-              MGMT_INTERFACE=eth0
-              SWITCH_INTERFACE_START=eth1
-              SWITCH_INTERFACE_COUNT=5
-              SWITCH_HOSTNAME=leaf02
-              CEOS_IMAGE=localhost/ceos:latest
-            owner: root:root
-            permissions: '0644'
-          - path: /etc/hotstack-ceos/startup-config
-            content: {get_file: leaf02-startup.cfg}
-            owner: root:root
-            permissions: '0644'
-        runcmd:
-          - systemctl start ceos.service
-
-  leaf02-machine-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:01"
-      fixed_ips:
-        - ip_address: 192.168.32.14
-
-  leaf02-switch-mgmt-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: machine-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:10"
-      fixed_ips:
-        - ip_address: 192.168.32.114
-
-  leaf02-spine01-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf02-spine01-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:02"
-
-  leaf02-spine02-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: leaf02-spine02-net}
-      port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:04"
-
-  leaf02-ironic1-br-port:
+  switch-ironic1-br-port:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
-      mac_address: "22:57:f8:dd:04:06"
+      mac_address: "22:57:f8:dd:01:07"
 
-  leaf02:
+  switch:
     type: OS::Nova::Server
+    depends_on: switch-trunk
     properties:
       image: {get_param: [switch_params, image]}
       flavor: {get_param: [switch_params, flavor]}
       config_drive: false
       networks:
-        - port: {get_resource: leaf02-machine-port}
-        - port: {get_resource: leaf02-switch-mgmt-port}
-        - port: {get_resource: leaf02-spine01-port}
-        - port: {get_resource: leaf02-spine02-port}
-        - port: {get_resource: leaf02-ironic0-br-port}
-        - port: {get_resource: leaf02-ironic1-br-port}
+        - port: {get_resource: switch-machine-port}
+        - port: {get_resource: switch-switch-mgmt-port}
+        - port: {get_attr: [switch-trunk, port_id]}
+        - port: {get_resource: switch-ironic0-br-port}
+        - port: {get_resource: switch-ironic1-br-port}
       user_data_format: RAW
-      user_data: {get_resource: leaf02-init}
+      user_data: {get_resource: switch-init}
 
   #
   # Devstack Instance
@@ -860,7 +481,6 @@ resources:
         hostname: devstack
         fqdn: devstack.stack.lab
 
-
   devstack-write-files:
     type: OS::Heat::CloudConfig
     properties:
@@ -869,11 +489,6 @@ resources:
           - path: /etc/hotstack/local.conf.j2
             content:
               get_file: local.conf.j2
-            owner: root:root
-            permissions: '0644'
-          - path: /etc/neutron/l2vni_network_nodes.yaml
-            content:
-              get_file: l2vni_network_nodes.yaml
             owner: root:root
             permissions: '0644'
 
@@ -897,29 +512,23 @@ resources:
   devstack-trunk-parent-port:
     type: OS::Neutron::Port
     properties:
-      network: {get_resource: devstack-br-net}
+      network: {get_resource: trunk-net}
       port_security_enabled: false
       mac_address: "fa:16:9e:81:f6:21"
 
-  devstack-public-vlan100-port:
-    type: OS::Neutron::Port
-    properties:
-      network: {get_resource: public-vlan100}
-      port_security_enabled: false
-
-  devstack-tenant-vlan103-port:
+  devstack-tenant-vlan103-subport:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan103}
       port_security_enabled: false
 
-  devstack-tenant-vlan104-port:
+  devstack-tenant-vlan104-subport:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan104}
       port_security_enabled: false
 
-  devstack-tenant-vlan105-port:
+  devstack-tenant-vlan105-subport:
     type: OS::Neutron::Port
     properties:
       network: {get_resource: tenant-vlan105}
@@ -930,16 +539,13 @@ resources:
     properties:
       port: {get_resource: devstack-trunk-parent-port}
       sub_ports:
-        - port: {get_resource: devstack-public-vlan100-port}
-          segmentation_id: 100
-          segmentation_type: vlan
-        - port: {get_resource: devstack-tenant-vlan103-port}
+        - port: {get_resource: devstack-tenant-vlan103-subport}
           segmentation_id: 103
           segmentation_type: vlan
-        - port: {get_resource: devstack-tenant-vlan104-port}
+        - port: {get_resource: devstack-tenant-vlan104-subport}
           segmentation_id: 104
           segmentation_type: vlan
-        - port: {get_resource: devstack-tenant-vlan105-port}
+        - port: {get_resource: devstack-tenant-vlan105-subport}
           segmentation_id: 105
           segmentation_type: vlan
 
@@ -968,18 +574,7 @@ resources:
     type: OS::Nova::Server
     properties:
       flavor: {get_param: [ironic_params, flavor]}
-      block_device_mapping_v2:
-        - device_type: disk
-          boot_index: 1
-          image_id: {get_param: [ironic_params, image]}
-          volume_size: 40
-          delete_on_termination: true
-        - device_type: cdrom
-          disk_bus: {get_param: cdrom_disk_bus}
-          boot_index: 0
-          image_id: {get_param: [ironic_params, cd_image]}
-          volume_size: 5
-          delete_on_termination: true
+      image: {get_param: [ironic_params, image]}
       networks:
         - port: {get_resource: ironic0-port}
 
@@ -993,18 +588,7 @@ resources:
     type: OS::Nova::Server
     properties:
       flavor: {get_param: [ironic_params, flavor]}
-      block_device_mapping_v2:
-        - device_type: disk
-          boot_index: 1
-          image_id: {get_param: [ironic_params, image]}
-          volume_size: 40
-          delete_on_termination: true
-        - device_type: cdrom
-          disk_bus: {get_param: cdrom_disk_bus}
-          boot_index: 0
-          image_id: {get_param: [ironic_params, cd_image]}
-          volume_size: 5
-          delete_on_termination: true
+      image: {get_param: [ironic_params, image]}
       networks:
         - port: {get_resource: ironic1-port}
 
@@ -1053,14 +637,14 @@ outputs:
               macaddress: "fa:16:9e:81:f6:20"
             dhcp4: true
             set-name: "enp3s0"
-            mtu: 1442
-          trunk0:
+            mtu: 1500
+          enp4s0:
             match:
               macaddress: "fa:16:9e:81:f6:21"
             dhcp4: false
             dhcp6: false
             set-name: trunk0
-            mtu: 1442
+            mtu: 1500
 
   sushy_emulator_uuids:
     description: UUIDs of instances to manage with sushy-tools - RedFish virtual BMC
@@ -1100,9 +684,9 @@ outputs:
             - address: {get_attr: [ironic0-port, mac_address]}
               physical_network: public
               local_link_connection:
-                switch_info: leaf02.stack.lab
-                switch_id: "22:57:f8:dd:04:01"
-                port_id: "Ethernet3"
+                switch_info: switch.stack.lab
+                switch_id: "22:57:f8:dd:01:01"
+                port_id: "Ethernet4"
         - name: ironic1
           driver: redfish
           bios_interface: no-bios
@@ -1127,9 +711,9 @@ outputs:
             - address: {get_attr: [ironic1-port, mac_address]}
               physical_network: public
               local_link_connection:
-                switch_info: leaf02.stack.lab
-                switch_id: "22:57:f8:dd:04:01"
-                port_id: "Ethernet4"
+                switch_info: switch.stack.lab
+                switch_id: "22:57:f8:dd:01:01"
+                port_id: "Ethernet8"
 
   ansible_inventory:
     description: Ansible inventory
@@ -1155,23 +739,8 @@ outputs:
             ansible_ssh_private_key_file: '~/.ssh/id_rsa'
       switches:
         hosts:
-          spine01:
-            ansible_host: {get_attr: [spine01-machine-port, fixed_ips, 0, ip_address]}
-            ansible_user: admin
-            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
-          spine02:
-            ansible_host: {get_attr: [spine02-machine-port, fixed_ips, 0, ip_address]}
-            ansible_user: admin
-            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
-          leaf01:
-            ansible_host: {get_attr: [leaf01-machine-port, fixed_ips, 0, ip_address]}
-            ansible_user: admin
-            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
-          leaf02:
-            ansible_host: {get_attr: [leaf02-machine-port, fixed_ips, 0, ip_address]}
+          switch:
+            ansible_host: {get_attr: [switch-machine-port, fixed_ips, 0, ip_address]}
             ansible_user: admin
             ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
             ansible_ssh_private_key_file: '~/.ssh/id_rsa'

--- a/scenarios/networking-lab/devstack-sonic-vlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vlan/local.conf.j2
@@ -1,0 +1,138 @@
+[[local|localrc]]
+# Credentials
+ADMIN_PASSWORD=secret
+DATABASE_PASSWORD=$ADMIN_PASSWORD
+RABBIT_PASSWORD=$ADMIN_PASSWORD
+SERVICE_PASSWORD=$ADMIN_PASSWORD
+
+# Service timeouts
+SERVICE_TIMEOUT=120
+
+# MTU - running inside an encapsulated environment, restrict to 1442 on the
+# physical network so VXLAN tenant networks get 1442 - 50 = 1392 effective MTU.
+PUBLIC_BRIDGE_MTU=1442
+
+# Networking
+HOST_IP=192.168.32.20
+SERVICE_HOST=$HOST_IP
+MYSQL_HOST=$HOST_IP
+RABBIT_HOST=$HOST_IP
+GLANCE_HOSTPORT=$HOST_IP:9292
+
+# Network ranges (avoiding Heat template allocations)
+FIXED_RANGE=172.20.100.0/24
+IPV4_ADDRS_SAFE_TO_USE=172.20.100.0/24
+FLOATING_RANGE=172.20.200.0/24
+PUBLIC_NETWORK_GATEWAY=172.20.200.1
+
+# Disable IPv6 - use IPv4 only
+IP_VERSION=4
+
+# Enable Neutron with OVN
+disable_service n-net
+enable_service q-svc
+# Disable traditional neutron agents
+disable_service q-agt
+disable_service q-dhcp
+disable_service q-l3
+disable_service q-meta
+# Enable OVN services
+enable_service ovn-northd
+enable_service ovn-controller
+enable_service q-ovn-metadata-agent
+# Enable Neutron trunk service
+enable_service neutron-trunk
+# Enable Neutron segments service
+enable_service neutron-segments
+
+enable_service ir-api
+enable_service ir-cond
+enable_service ir-neutronagt
+
+# Ironic configuration
+VIRT_DRIVER=ironic
+DEFAULT_INSTANCE_TYPE=baremetal
+IRONIC_BAREMETAL_BASIC_OPS=True
+IRONIC_IS_HARDWARE=True
+IRONIC_VM_COUNT=0
+IRONIC_NETWORK_SIMULATOR=none
+IRONIC_BUILD_DEPLOY_RAMDISK=False
+IRONIC_DEPLOY_DRIVER=redfish
+IRONIC_ENABLED_HARDWARE_TYPES=redfish
+IRONIC_ENABLED_BOOT_INTERFACES=ipxe,redfish-virtual-media,http-ipxe
+IRONIC_ENABLED_POWER_INTERFACES=redfish
+IRONIC_ENABLED_MANAGEMENT_INTERFACES=redfish
+IRONIC_ENABLED_DEPLOY_INTERFACES=direct,ramdisk
+IRONIC_NETWORK_INTERFACE=neutron
+IRONIC_ENABLED_NETWORK_INTERFACES=neutron
+IRONIC_AUTOMATED_CLEAN_ENABLED=True
+FORCE_CONFIG_DRIVE=True
+
+# Ironic network configuration - use provisioning vxlan network for all operations
+IRONIC_PROVISION_NETWORK_NAME=provisioning
+IRONIC_PROVISION_PROVIDER_NETWORK_TYPE=vlan
+IRONIC_PROVISION_SUBNET_PREFIX=10.0.5.0/24
+IRONIC_PROVISION_SUBNET_GATEWAY=10.0.5.1
+IRONIC_CLEAN_NET_NAME=provisioning
+IRONIC_RESCUE_NET_NAME=provisioning
+IRONIC_INSPECTION_NET_NAME=provisioning
+
+# Networking configuration for ML2 with OVN and Generic Switch
+Q_PLUGIN=ml2
+Q_ML2_TENANT_NETWORK_TYPE=vlan
+Q_ML2_PLUGIN_MECHANISM_DRIVERS=ovn,genericswitch,baremetal
+Q_ML2_PLUGIN_TYPE_DRIVERS=vxlan,geneve,vlan,flat
+ENABLE_TENANT_VLANS=True
+TENANT_VLAN_RANGE=103:105
+PHYSICAL_NETWORK=public
+
+# Physical interface mapping
+# The second interface (trunk port) will be added to br-ex
+# trunk0 is matched by MAC address fa:16:9e:81:f6:21 and renamed by netplan
+PUBLIC_INTERFACE=trunk0
+OVS_PHYSICAL_BRIDGE=br-ex
+PUBLIC_BRIDGE=br-ex
+
+# OVN Configuration
+Q_USE_PROVIDERNET_FOR_PUBLIC=True
+OVN_L3_CREATE_PUBLIC_NETWORK=True
+OVN_BRIDGE_MAPPINGS=public:br-ex
+
+# Enable Ironic
+enable_plugin ironic https://opendev.org/openstack/ironic
+
+# Enable networking-generic-switch plugin
+enable_plugin networking-generic-switch https://opendev.org/openstack/networking-generic-switch
+
+# Enable networking-baremetal plugin
+enable_plugin networking-baremetal https://opendev.org/openstack/networking-baremetal
+
+# Disable Swift (optional, not needed for this setup)
+disable_service s-proxy s-object s-container s-account
+
+# Disable Horizon dashboard
+disable_service horizon
+
+[[post-config|$NEUTRON_CONF]]
+[DEFAULT]
+global_physnet_mtu = 1500
+
+[l2vni]
+enable_l2vni_trunk_reconciliation = False
+enable_l2vni_trunk_reconciliation_events = False
+
+[baremetal_agent]
+enable_ha_chassis_group_alignment = False
+enable_router_ha_binding_events = False
+
+[[post-config|/etc/neutron/plugins/ml2/ml2_conf_genericswitch.ini]]
+[genericswitch:switch]
+device_type = netmiko_sonic
+ip = switch.stack.lab
+username = admin
+password = password
+secret = password
+ngs_mac_address = 22:57:f8:dd:01:01
+ngs_disable_inactive_ports = true
+ngs_physical_networks = public
+ngs_trunk_ports = Ethernet0

--- a/scenarios/networking-lab/devstack-sonic-vlan/switch-bgpd.conf
+++ b/scenarios/networking-lab/devstack-sonic-vlan/switch-bgpd.conf
@@ -1,0 +1,4 @@
+!
+! BGP configuration for VLAN-only scenario
+! No BGP routing needed - file present only to satisfy setup-sonic requirements
+!

--- a/scenarios/networking-lab/devstack-sonic-vlan/switch-config_db.json
+++ b/scenarios/networking-lab/devstack-sonic-vlan/switch-config_db.json
@@ -1,0 +1,54 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hostname": "switch",
+            "type": "ToRRouter",
+            "docker_routing_config_mode": "unified"
+        }
+    },
+    "MGMT_INTERFACE": {
+        "eth0|192.168.32.111/24": {
+            "gwaddr": "192.168.32.1"
+        }
+    },
+    "MGMT_PORT": {
+        "eth0": {
+            "alias": "eth0",
+            "admin_status": "up"
+        }
+    },
+    "MGMT_VRF_CONFIG": {
+        "vrf_global": {
+            "mgmtVrfEnabled": "true"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "fortyGigE0/0",
+            "lanes": "25,26,27,28",
+            "speed": "40000",
+            "admin_status": "up",
+            "mtu": "1500"
+        },
+        "Ethernet4": {
+            "alias": "fortyGigE0/4",
+            "lanes": "29,30,31,32",
+            "speed": "40000",
+            "admin_status": "up",
+            "mtu": "1500"
+        },
+        "Ethernet8": {
+            "alias": "fortyGigE0/8",
+            "lanes": "33,34,35,36",
+            "speed": "40000",
+            "admin_status": "up",
+            "mtu": "1500"
+        }
+    },
+    "VLAN": {
+        "Vlan100": {
+            "vlanid": "100"
+        }
+    },
+    "VLAN_MEMBER": {}
+}

--- a/scenarios/networking-lab/devstack-sonic-vlan/switch-ospfd.conf
+++ b/scenarios/networking-lab/devstack-sonic-vlan/switch-ospfd.conf
@@ -1,0 +1,4 @@
+!
+! OSPF configuration for VLAN-only scenario
+! No OSPF routing needed - file present only to satisfy setup-sonic requirements
+!

--- a/scenarios/networking-lab/devstack-sonic-vlan/topology-diagram.svg
+++ b/scenarios/networking-lab/devstack-sonic-vlan/topology-diagram.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="800" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <style>
+      .switch-box { fill: #4A90E2; stroke: #2E5C8A; stroke-width: 2; }
+      .server-box { fill: #7ED321; stroke: #5FA019; stroke-width: 2; }
+      .controller-box { fill: #F5A623; stroke: #D68910; stroke-width: 2; }
+      .switch-text { fill: white; font-family: Arial, sans-serif; font-size: 14px; font-weight: bold; text-anchor: middle; }
+      .label-text { fill: rgba(255, 255, 255, 0.9); font-family: Arial, sans-serif; font-size: 11px; text-anchor: middle; }
+      .ip-text { fill: rgba(255, 255, 255, 0.85); font-family: monospace; font-size: 10px; text-anchor: middle; }
+      .link-line { stroke: #6a737d; stroke-width: 2; fill: none; }
+      .link-label { fill: #8b949e; font-family: monospace; font-size: 9px; text-anchor: middle; }
+      .mgmt-line { stroke: #F5A623; stroke-width: 2; stroke-dasharray: 5,5; fill: none; }
+      .bg-label { fill: #6a737d; font-family: Arial, sans-serif; font-size: 11px; text-anchor: middle; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="25" style="font-family: Arial; font-size: 20px; font-weight: bold; text-anchor: middle; fill: #6a737d;">
+    VLAN Trunking Topology
+  </text>
+
+  <!-- Management Network Line -->
+  <line x1="50" y1="60" x2="750" y2="60" class="mgmt-line"/>
+  <text x="400" y="53" class="bg-label">Management Network (192.168.32.0/24)</text>
+
+  <!-- Controller -->
+  <rect x="650" y="80" width="100" height="60" rx="5" class="controller-box"/>
+  <text x="700" y="105" class="switch-text">controller</text>
+  <text x="700" y="125" class="ip-text">192.168.32.254</text>
+
+  <!-- Switch -->
+  <rect x="350" y="180" width="120" height="70" rx="5" class="switch-box"/>
+  <text x="410" y="205" class="switch-text">switch</text>
+  <text x="410" y="222" class="label-text">VLANs 100-105</text>
+  <text x="410" y="237" class="ip-text">192.168.32.11</text>
+
+  <!-- Server Nodes -->
+  <!-- Devstack -->
+  <rect x="100" y="350" width="100" height="60" rx="5" class="server-box"/>
+  <text x="150" y="375" class="switch-text">devstack</text>
+  <text x="150" y="395" class="ip-text">192.168.32.20</text>
+
+  <!-- Ironic0 -->
+  <rect x="450" y="350" width="100" height="60" rx="5" class="server-box"/>
+  <text x="500" y="375" class="switch-text">ironic0</text>
+  <text x="500" y="395" class="ip-text">BM Node</text>
+
+  <!-- Ironic1 -->
+  <rect x="600" y="350" width="100" height="60" rx="5" class="server-box"/>
+  <text x="650" y="375" class="switch-text">ironic1</text>
+  <text x="650" y="395" class="ip-text">BM Node</text>
+
+  <!-- Server to Switch connections -->
+  <!-- Devstack to Switch -->
+  <line x1="170" y1="350" x2="380" y2="250" class="link-line"/>
+  <text x="240" y="295" class="link-label">Ethernet8 (trunk)</text>
+
+  <!-- Ironic0 to Switch -->
+  <line x1="480" y1="350" x2="420" y2="250" class="link-line"/>
+  <text x="440" y="295" class="link-label">Ethernet12</text>
+
+  <!-- Ironic1 to Switch -->
+  <line x1="630" y1="350" x2="450" y2="250" class="link-line"/>
+  <text x="555" y="295" class="link-label">Ethernet16</text>
+
+  <!-- Legend -->
+  <g transform="translate(50, 120)">
+    <text x="0" y="0" style="font-family: Arial; font-size: 12px; font-weight: bold; fill: #6a737d;">Legend</text>
+    <rect x="0" y="10" width="30" height="20" rx="3" class="switch-box"/>
+    <text x="35" y="25" style="font-family: Arial; font-size: 11px; fill: #6a737d;">Switch</text>
+    <rect x="0" y="35" width="30" height="20" rx="3" class="server-box"/>
+    <text x="35" y="50" style="font-family: Arial; font-size: 11px; fill: #6a737d;">Server</text>
+    <rect x="0" y="60" width="30" height="20" rx="3" class="controller-box"/>
+    <text x="35" y="75" style="font-family: Arial; font-size: 11px; fill: #6a737d;">Controller</text>
+    <line x1="0" y1="90" x2="30" y2="90" class="link-line"/>
+    <text x="35" y="95" style="font-family: Arial; font-size: 11px; fill: #6a737d;">Link</text>
+    <line x1="0" y1="105" x2="30" y2="105" class="mgmt-line"/>
+    <text x="35" y="110" style="font-family: Arial; font-size: 11px; fill: #6a737d;">Management</text>
+  </g>
+
+  <!-- Notes -->
+  <text x="400" y="460" style="font-family: Arial; font-size: 10px; text-anchor: middle; fill: #8b949e;">
+    Ethernet8: Trunk port with VLANs 100-105 | Ethernet12, Ethernet16: Access ports for Ironic nodes
+  </text>
+  <text x="400" y="475" style="font-family: Arial; font-size: 10px; text-anchor: middle; fill: #8b949e;">
+    networking-generic-switch manages VLAN membership dynamically
+  </text>
+</svg>

--- a/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
@@ -519,7 +519,6 @@ resources:
       image: {get_param: [switch_params, image]}
       flavor: {get_param: [switch_params, flavor]}
       config_drive: false
-      diskConfig: MANUAL
       networks:
         - port: {get_resource: spine01-machine-port}
         - port: {get_resource: spine01-switch-mgmt-port}
@@ -624,7 +623,6 @@ resources:
       image: {get_param: [switch_params, image]}
       flavor: {get_param: [switch_params, flavor]}
       config_drive: false
-      diskConfig: MANUAL
       networks:
         - port: {get_resource: spine02-machine-port}
         - port: {get_resource: spine02-switch-mgmt-port}
@@ -794,7 +792,6 @@ resources:
       image: {get_param: [switch_params, image]}
       flavor: {get_param: [switch_params, flavor]}
       config_drive: false
-      diskConfig: MANUAL
       networks:
         - port: {get_resource: leaf01-machine-port}
         - port: {get_resource: leaf01-switch-mgmt-port}
@@ -900,7 +897,6 @@ resources:
       image: {get_param: [switch_params, image]}
       flavor: {get_param: [switch_params, flavor]}
       config_drive: false
-      diskConfig: MANUAL
       networks:
         - port: {get_resource: leaf02-machine-port}
         - port: {get_resource: leaf02-switch-mgmt-port}


### PR DESCRIPTION
Create simplified VLAN-only networking lab with single SONiC switch, devstack, and 2 ironic nodes. L2 VLAN switching for testing networking-generic-switch ML2 plugin.

Also remove diskConfig: MANUAL from SONiC/cEOS switch instances to allow Nova disk resizing.

Assisted-By: Claude (claude-4.5-sonnet)