### PR TITLE
Add cEOS promisc option and refresh docs

### DIFF
--- a/images/dib/elements/hotstack-ceos/README.rst
+++ b/images/dib/elements/hotstack-ceos/README.rst
@@ -3,7 +3,9 @@ hotstack-ceos
 ==============
 
 This element creates a CentOS 9 Stream image that runs Arista cEOS
-(containerized EOS) as a podman container with macvlan networking.
+(containerized EOS) in a privileged Podman container. Dataplane NICs on the
+guest are moved into the cEOS container's network namespace so the switch
+sees them as its own interfaces.
 
 Environment Variables
 =====================
@@ -19,14 +21,21 @@ The image includes:
 
 - Podman for running the cEOS container
 - Systemd service (ceos.service) to manage the container lifecycle
-- Python startup script (start-ceos) that creates macvlan interfaces
+- Python startup script (start-ceos) that moves host interfaces into the
+  cEOS container namespace and starts the switch
 - Default minimal startup configuration for SSH access
-- Python common functions library for configuration management
 
 Configuration
 =============
 
 The cEOS switch is configured via cloud-init by writing to
-/etc/hotstack-ceos/config and /etc/hotstack-ceos/startup-config.
+``/etc/hotstack-ceos/config`` and ``/etc/hotstack-ceos/startup-config``.
+
+``/etc/hotstack-ceos/config`` is a shell-style ``KEY=value`` file. Besides
+interface and image settings, ``ENABLE_SWITCH_PORT_PROMISC`` controls promiscuous
+mode on container dataplane interfaces (``eth1`` onward). Only the value
+``false`` (case-insensitive) disables it; any other value enables it, and the
+same applies when the key is omitted. The first interface moved into the pod
+(container ``eth0``, typically Management0) is never set promiscuous.
 
 See the plan document for details on cloud-init configuration patterns.

--- a/images/dib/elements/hotstack-ceos/static/etc/hotstack-ceos/README
+++ b/images/dib/elements/hotstack-ceos/static/etc/hotstack-ceos/README
@@ -1,7 +1,7 @@
 This directory contains cEOS runtime configuration files.
 
 Files in this directory:
-- config: Runtime configuration for the cEOS container
+- config: Runtime configuration for the cEOS container (see ENABLE_SWITCH_PORT_PROMISC)
 - startup-config: EOS startup configuration
 
 These files are typically populated by cloud-init user-data during instance boot.

--- a/images/dib/elements/hotstack-ceos/static/usr/local/bin/start-ceos
+++ b/images/dib/elements/hotstack-ceos/static/usr/local/bin/start-ceos
@@ -56,6 +56,7 @@ class CeosConfig:
         self.switch_interface_count = 5
         self.switch_hostname = "ceos"
         self.ceos_image = "localhost/ceos:latest"
+        self.enable_switch_port_promisc = True
 
     def load_from_file(self, config_file: str = CONFIG_FILE) -> None:
         """Load configuration from shell-style config file.
@@ -87,6 +88,8 @@ class CeosConfig:
                         self.switch_hostname = value
                     elif key == "CEOS_IMAGE":
                         self.ceos_image = value
+                    elif key == "ENABLE_SWITCH_PORT_PROMISC":
+                        self.enable_switch_port_promisc = value.lower() != "false"
 
     def log_config(self) -> None:
         """Log the current configuration to stderr."""
@@ -96,6 +99,9 @@ class CeosConfig:
         LOG.info(f"  Switch Interface Count: {self.switch_interface_count}")
         LOG.info(f"  Switch Hostname: {self.switch_hostname}")
         LOG.info(f"  cEOS Image: {self.ceos_image}")
+        LOG.info(
+            f"  Enable switch port promisc (eth1+): {self.enable_switch_port_promisc}"
+        )
 
 
 def run_command(
@@ -259,7 +265,10 @@ def parse_interface_name(interface: str) -> Tuple[str, int]:
 
 
 def attach_interface_to_container(
-    interface: str, container_pid: int, container_if_name: str
+    interface: str,
+    container_pid: int,
+    container_if_name: str,
+    config: CeosConfig,
 ):
     """Attach a network interface to the container namespace.
 
@@ -268,6 +277,7 @@ def attach_interface_to_container(
     :param interface: Host interface name to move
     :param container_pid: PID of the target container
     :param container_if_name: New name for the interface inside the container
+    :param config: Host configuration (promisc on dataplane eth1+ if enabled)
     """
     LOG.info(f"Attaching {interface} to container as {container_if_name}...")
 
@@ -302,6 +312,23 @@ def attach_interface_to_container(
             "up",
         ]
     )
+
+    if config.enable_switch_port_promisc and container_if_name != "eth0":
+        LOG.info(f"Enabling promiscuous mode on {container_if_name} in container...")
+        run_command(
+            [
+                "nsenter",
+                "-t",
+                str(container_pid),
+                "-n",
+                "ip",
+                "link",
+                "set",
+                container_if_name,
+                "promisc",
+                "on",
+            ]
+        )
 
 
 def start_ceos_container(config: CeosConfig):
@@ -419,7 +446,7 @@ def setup_networking(config: CeosConfig):
             continue
 
         LOG.info(f"Moving {host_if} to container as {container_if}...")
-        attach_interface_to_container(host_if, container_pid, container_if)
+        attach_interface_to_container(host_if, container_pid, container_if, config)
 
     LOG.info("Networking setup complete")
     return True

--- a/scenarios/networking-lab/devstack-ceos-vlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-ceos-vlan/heat_template.yaml
@@ -338,6 +338,7 @@ resources:
               SWITCH_INTERFACE_COUNT=4
               SWITCH_HOSTNAME=switch
               CEOS_IMAGE=localhost/ceos:latest
+              ENABLE_SWITCH_PORT_PROMISC=true
             owner: root:root
             permissions: '0644'
           - path: /etc/hotstack-ceos/startup-config

--- a/scenarios/networking-lab/devstack-ceos-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-ceos-vxlan/heat_template.yaml
@@ -447,6 +447,7 @@ resources:
               SWITCH_INTERFACE_COUNT=4
               SWITCH_HOSTNAME=spine01
               CEOS_IMAGE=localhost/ceos:latest
+              ENABLE_SWITCH_PORT_PROMISC=true
             owner: root:root
             permissions: '0644'
           - path: /etc/hotstack-ceos/startup-config
@@ -533,6 +534,7 @@ resources:
               SWITCH_INTERFACE_COUNT=4
               SWITCH_HOSTNAME=spine02
               CEOS_IMAGE=localhost/ceos:latest
+              ENABLE_SWITCH_PORT_PROMISC=true
             owner: root:root
             permissions: '0644'
           - path: /etc/hotstack-ceos/startup-config
@@ -623,6 +625,7 @@ resources:
               SWITCH_INTERFACE_COUNT=5
               SWITCH_HOSTNAME=leaf01
               CEOS_IMAGE=localhost/ceos:latest
+              ENABLE_SWITCH_PORT_PROMISC=true
             owner: root:root
             permissions: '0644'
           - path: /etc/hotstack-ceos/startup-config
@@ -771,6 +774,7 @@ resources:
               SWITCH_INTERFACE_COUNT=5
               SWITCH_HOSTNAME=leaf02
               CEOS_IMAGE=localhost/ceos:latest
+              ENABLE_SWITCH_PORT_PROMISC=true
             owner: root:root
             permissions: '0644'
           - path: /etc/hotstack-ceos/startup-config


### PR DESCRIPTION
Enable optional promisc on cEOS dataplane ports (eth1+), keeping container eth0/Management0 non-promiscuous.

Update element/scenario docs and examples to match behavior.

Assisted-By: Claude (claude-4.5-sonnet)