### PR TITLE
Set Ironic power timeout to 90s for lab scenarios.

### DIFF
--- a/scenarios/networking-lab/devstack-ceos-vlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-ceos-vlan/local.conf.j2
@@ -113,6 +113,10 @@ disable_service s-proxy s-object s-container s-account
 # Disable Horizon dashboard
 disable_service horizon
 
+[[post-config|/etc/ironic/ironic.conf]]
+[conductor]
+power_state_change_timeout = 90
+
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1500

--- a/scenarios/networking-lab/devstack-ceos-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-ceos-vxlan/local.conf.j2
@@ -116,6 +116,10 @@ disable_service s-proxy s-object s-container s-account
 # Disable Horizon dashboard
 disable_service horizon
 
+[[post-config|/etc/ironic/ironic.conf]]
+[conductor]
+power_state_change_timeout = 90
+
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1442

--- a/scenarios/networking-lab/devstack-nxsw-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-nxsw-vxlan/local.conf.j2
@@ -116,6 +116,10 @@ disable_service s-proxy s-object s-container s-account
 # Disable Horizon dashboard
 disable_service horizon
 
+[[post-config|/etc/ironic/ironic.conf]]
+[conductor]
+power_state_change_timeout = 90
+
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1442

--- a/scenarios/networking-lab/devstack-sonic-vlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vlan/local.conf.j2
@@ -113,6 +113,10 @@ disable_service s-proxy s-object s-container s-account
 # Disable Horizon dashboard
 disable_service horizon
 
+[[post-config|/etc/ironic/ironic.conf]]
+[conductor]
+power_state_change_timeout = 90
+
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1500

--- a/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/local.conf.j2
@@ -115,6 +115,10 @@ disable_service s-proxy s-object s-container s-account
 # Disable Horizon dashboard
 disable_service horizon
 
+[[post-config|/etc/ironic/ironic.conf]]
+[conductor]
+power_state_change_timeout = 90
+
 [[post-config|$NEUTRON_CONF]]
 [DEFAULT]
 global_physnet_mtu = 1500


### PR DESCRIPTION
Set conductor power_state_change_timeout=90 in five scenarios.

Assisted-By: Claude (claude-4.6-sonnet-medium)