### PR TITLE
NXOS - firmware v10.x DIB image + NETCONF scenario

### DIFF
--- a/02-bootstrap_controller.yml
+++ b/02-bootstrap_controller.yml
@@ -29,3 +29,4 @@
       vars:
         controller_ansible_host: "{{ stack_outputs.controller_ansible_host }}"
         ansible_inventory: "{{ stack_outputs.ansible_inventory }}"
+        wait_for_hosts: "{{ stack_outputs.wait_for_hosts | default([]) }}"

--- a/images/Makefile
+++ b/images/Makefile
@@ -30,6 +30,11 @@ SONIC_IMAGE_FORMAT           ?= qcow2
 SONIC_DIB_VENV               ?= $(HOME)/sonic-dib-venv
 SONIC_DIB_WORKDIR            ?= $(CURDIR)/.sonic-build
 SONIC_DOCKER_IMAGE           ?=
+NXOS_IMAGE_NAME              ?= nxos-switch-host.qcow2
+NXOS_IMAGE_FORMAT            ?= qcow2
+NXOS_DIB_VENV                ?= $(HOME)/nxos-dib-venv
+NXOS_DIB_WORKDIR             ?= $(CURDIR)/.nxos-build
+NXOS_QCOW2_IMAGE             ?=
 
 # Switch vendor image locations (optional, leave empty if not available)
 # These will be copied into the image at /opt/<model>/ during build
@@ -369,4 +374,59 @@ sonic_clean:
 	fi
 	@if [ -d "$(SONIC_DIB_WORKDIR)" ]; then \
 		sudo rm -rf $(SONIC_DIB_WORKDIR); \
+	fi
+
+nxos: nxos_verify_image nxos_dib_setup nxos_dib_build nxos_convert
+
+nxos_verify_image:
+	@if [ -z "$(NXOS_QCOW2_IMAGE)" ]; then \
+		echo "ERROR: NXOS_QCOW2_IMAGE is not set."; \
+		echo "Please provide the path to the NXOS qcow2 file:"; \
+		echo "  make nxos NXOS_QCOW2_IMAGE=/path/to/nexus9300v64.10.5.3.F.qcow2"; \
+		exit 1; \
+	fi
+	@test -f $(NXOS_QCOW2_IMAGE) || (echo "ERROR: NXOS image not found: $(NXOS_QCOW2_IMAGE)" && exit 1)
+	@echo "Using NXOS image: $(NXOS_QCOW2_IMAGE)"
+
+nxos_dib_setup:
+	@if [ ! -d "$(NXOS_DIB_VENV)" ]; then \
+		echo "Creating Python virtual environment at $(NXOS_DIB_VENV)..."; \
+		python3 -m venv $(NXOS_DIB_VENV); \
+		. $(NXOS_DIB_VENV)/bin/activate && \
+		pip install --upgrade pip setuptools wheel && \
+		pip install diskimage-builder; \
+	else \
+		echo "Virtual environment already exists at $(NXOS_DIB_VENV)"; \
+	fi
+
+nxos_dib_build: nxos_dib_setup
+	@echo "Building NXOS image using diskimage-builder..."
+	@mkdir -p $(NXOS_DIB_WORKDIR)/cache
+	@. $(NXOS_DIB_VENV)/bin/activate && \
+		cd $(CURDIR) && \
+		ELEMENTS_PATH=$(CURDIR)/dib/elements \
+		DIB_IMAGE_CACHE=$(NXOS_DIB_WORKDIR)/cache \
+		DIB_DEBUG_TRACE=1 \
+		DIB_NXOS_IMAGE=$(NXOS_QCOW2_IMAGE) \
+		diskimage-builder dib/nxos-image.yaml
+	@echo "NXOS image built successfully: $(NXOS_IMAGE_NAME)"
+
+nxos_convert:
+ifeq ($(NXOS_IMAGE_FORMAT),raw)
+	@echo "Converting NXOS image to raw format (in-place)..."
+	qemu-img convert -p -f qcow2 -O raw $(NXOS_IMAGE_NAME) $(NXOS_IMAGE_NAME).tmp
+	mv $(NXOS_IMAGE_NAME).tmp $(NXOS_IMAGE_NAME)
+	@echo "NXOS image converted to raw format: $(NXOS_IMAGE_NAME)"
+endif
+
+nxos_clean:
+	rm -f $(NXOS_IMAGE_NAME)
+	rm -f $(NXOS_IMAGE_NAME).tmp
+	rm -rf $(NXOS_DIB_VENV)
+	@if [ -z "$(NXOS_DIB_WORKDIR)" ] || [ "$(NXOS_DIB_WORKDIR)" = "/" ]; then \
+		echo "ERROR: NXOS_DIB_WORKDIR is not set or is dangerous: $(NXOS_DIB_WORKDIR)"; \
+		exit 1; \
+	fi
+	@if [ -d "$(NXOS_DIB_WORKDIR)" ]; then \
+		sudo rm -rf $(NXOS_DIB_WORKDIR); \
 	fi

--- a/images/README.md
+++ b/images/README.md
@@ -27,6 +27,10 @@ deployments. The tasks are executed using the `make` utility.
 - **ceos**: A CentOS 9 Stream image that runs Arista cEOS (containerized EOS) as
   a podman container with macvlan networking. Built using diskimage-builder (DIB)
   with the `hotstack-ceos` element
+- **nxos**: A CentOS 9 Stream image that runs Cisco NXOS (Nexus 9300v) as a
+  nested KVM virtual machine with macvtap passthrough networking. Uses GNS3's
+  custom OVMF firmware for UEFI boot. Built using diskimage-builder (DIB) with
+  the `hotstack-nxos` element
 
 ## Download Pre-built Images
 
@@ -105,6 +109,16 @@ The following sections describe how to build images locally using the included M
   (default: `.ceos-build`).
 - `CEOS_TAR_IMAGE`: Path to the Arista cEOS tar.xz image file (e.g.,
   `cEOS64-lab-4.35.3F.tar.xz`). This is required when building the cEOS image.
+- `NXOS_IMAGE_NAME`: The name of the NXOS image file to be created (default:
+  `nxos-switch-host.qcow2`).
+- `NXOS_IMAGE_FORMAT`: The desired format for the NXOS image (default: `qcow2`).
+  Set to `raw` to convert to raw format after building.
+- `NXOS_DIB_VENV`: Path to the Python virtual environment for diskimage-builder
+  (default: `~/nxos-dib-venv`).
+- `NXOS_DIB_WORKDIR`: Working directory for DIB build artifacts and cache
+  (default: `.nxos-build`).
+- `NXOS_QCOW2_IMAGE`: Path to the Cisco NXOS qcow2 image file (e.g.,
+  `nexus9300v64.10.5.3.F.qcow2`). This is required when building the NXOS image.
 
 **Note**: Raw format is required for cloud backends using Ceph, as Ceph cannot
 directly use qcow2 images for VM disks.
@@ -163,6 +177,19 @@ directly use qcow2 images for VM disks.
   - `switch-host_convert`: A target that converts the image to the format
     specified by `SWITCH_HOST_IMAGE_FORMAT` (in-place conversion if `raw`).
   - `switch-host_clean`: A target that removes the switch-host image file.
+- `nxos`: Builds the NXOS switch-host image using diskimage-builder (DIB).
+  Depends on `nxos_verify_image`, `nxos_dib_setup`, `nxos_dib_build`, and
+  `nxos_convert`. Not included in `all` or `clean` targets.
+  - `nxos_verify_image`: Validates that `NXOS_QCOW2_IMAGE` is set and exists.
+  - `nxos_dib_setup`: Creates a Python virtual environment and installs
+    diskimage-builder.
+  - `nxos_dib_build`: Builds the NXOS image using DIB with the configuration
+    from `dib/nxos-image.yaml` and the custom `hotstack-nxos` element from
+    `dib/elements/`.
+  - `nxos_convert`: Converts the image to the format specified by
+    `NXOS_IMAGE_FORMAT` (in-place conversion if `raw`).
+  - `nxos_clean`: Removes the NXOS image, virtual environment, and build
+    artifacts.
 
 ### MicroShift Image Variables
 
@@ -435,3 +462,49 @@ make clean
 3. See `dib/elements/hotstack-ceos/README.rst` for details on runtime
    configuration via cloud-init, including network interface setup and startup
    configuration.
+
+#### Building and uploading the NXOS image to glance
+
+1. Build the NXOS image (using diskimage-builder):
+
+   ```shell
+   make nxos NXOS_QCOW2_IMAGE=/path/to/nexus9300v64.10.5.3.F.qcow2
+   ```
+
+   This will create a Python virtual environment, install diskimage-builder,
+   download the GNS3 OVMF firmware, build the image using the configuration
+   from `dib/nxos-image.yaml`, and keep it in qcow2 format (default).
+
+2. Upload the NXOS image to Glance:
+
+   ```shell
+   openstack image create hotstack-nxos \
+     --disk-format qcow2 \
+     --file nxos-switch-host.qcow2 \
+     --property hw_firmware_type=uefi \
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
+   ```
+
+   **Note**: The `hw_vif_model=e1000` property is recommended for switch images
+   to avoid virtio checksum offloading issues when connected via OVS/OVN bridge
+   networks.
+
+   **Note**: To convert to raw format (required for Ceph backends):
+
+   ```shell
+   make nxos \
+     NXOS_QCOW2_IMAGE=/path/to/nexus9300v64.10.5.3.F.qcow2 \
+     NXOS_IMAGE_FORMAT=raw
+
+   openstack image create hotstack-nxos \
+     --disk-format raw \
+     --file nxos-switch-host.qcow2 \
+     --property hw_firmware_type=uefi \
+     --property hw_machine_type=q35 \
+     --property hw_vif_model=e1000
+   ```
+
+3. See `dib/elements/hotstack-nxos/README.rst` for details on runtime
+   configuration via cloud-init, including macvtap passthrough networking,
+   NXOS interface mapping, and POAP bootstrap support.

--- a/images/dib/elements/hotstack-nxos/README.rst
+++ b/images/dib/elements/hotstack-nxos/README.rst
@@ -1,0 +1,145 @@
+=============
+hotstack-nxos
+=============
+
+This element creates a CentOS 9 Stream image that runs Cisco NXOS
+(Nexus 9300v) as a nested KVM virtual machine. NXOS v64.10.x cannot boot
+directly as an OpenStack VM due to UEFI firmware requirements -- it needs
+GNS3's custom OVMF firmware (``OVMF-edk2-stable202305.fd``). Dataplane NICs
+on the guest are passed through to the NXOS VM via macvtap in passthru mode
+so the switch sees them with the original MAC addresses from OpenStack ports.
+
+Environment Variables
+=====================
+
+DIB_NXOS_IMAGE
+  Path to the NXOS qcow2 image file (e.g., nexus9300v-10.4.3.qcow2).
+  This is required and must be provided when building the image.
+
+DIB_NXOS_OVMF_URL
+  URL to download the GNS3 OVMF firmware zip file. Defaults to
+  ``https://github.com/GNS3/gns3-registry/raw/master/OVMF-edk2-stable202305.fd.zip``.
+  Override this to use a local mirror or a different firmware version.
+
+Overview
+========
+
+The image includes:
+
+- QEMU/KVM for running the NXOS VM as a nested guest
+- GNS3 custom OVMF firmware embedded at build time
+- A single systemd service (``nxos.service``, Type=simple) that performs
+  setup and execs into ``qemu-kvm``
+- A console logger service (``nxos-console.service``) that connects to the
+  NXOS serial console and streams output to journald
+- Bash startup script (``start-nxos``) that creates macvtap interfaces,
+  prepares a QEMU disk overlay, opens tap FDs, and execs into QEMU
+- NetworkManager configuration to leave switch data interfaces unmanaged
+
+Configuration
+=============
+
+The NXOS switch is configured via cloud-init by writing to
+``/etc/hotstack-nxos/config``.
+
+``/etc/hotstack-nxos/config`` is a shell-style ``KEY=value`` file with the
+following variables:
+
+MGMT_INTERFACE
+  Host management interface (default: ``eth0``).
+
+SWITCH_INTERFACE_START
+  First switch data interface (default: ``eth1``).
+
+SWITCH_INTERFACE_COUNT
+  Number of switch data interfaces (default: ``4``).
+
+NXOS_RAM
+  RAM for the NXOS VM in MB (default: ``8192``).
+
+NXOS_VCPUS
+  vCPUs for the NXOS VM (default: ``2``).
+
+CONSOLE_PORT
+  Telnet console port (default: ``55001``).
+
+
+Interface Mapping
+=================
+
+Host interfaces are passed through to the NXOS VM via macvtap devices:
+
+- Host ``eth0`` = Host management
+- Host ``eth1`` = NXOS ``mgmt0``
+- Host ``eth2`` = NXOS ``Ethernet1/1``
+- Host ``eth3``+ = NXOS ``Ethernet1/2``+
+
+Each macvtap device is created in passthru mode, preserving the original MAC
+address from the OpenStack port. This enables POAP (Power-On Auto
+Provisioning) via DHCP on the NXOS ``mgmt0`` interface.
+
+Macvtap Architecture
+====================
+
+Macvtap devices in passthru mode provide direct L2 access between the host
+NICs and the NXOS VM, preserving the original MAC addresses without bridging.
+
+The ``start-nxos`` script handles setup and QEMU launch in a single process:
+
+1. Read configuration from ``/etc/hotstack-nxos/config``
+2. Bring up host data interfaces (``eth1``-``eth4``)
+3. Create macvtap devices in passthru mode (``macvtap-eth1``, etc.)
+4. Create a QEMU overlay disk backed by the base NXOS qcow2
+5. Open ``/dev/tapN`` file descriptors for each macvtap device
+6. ``exec`` into ``qemu-kvm`` with ``-machine q35``, ``-enable-kvm``,
+   GNS3 OVMF BIOS, and ``e1000`` NICs bound to the macvtap FDs
+
+Since the script execs into QEMU, systemd manages the QEMU process directly
+(``Type=simple``, ``Restart=on-failure``). All setup steps are idempotent so
+restarts work without manual cleanup.
+
+Startup Sequence
+================
+
+1. **Cloud-init** writes ``/etc/hotstack-nxos/config`` with MAC addresses
+   and interface settings.
+
+2. **nxos.service** (simple) runs ``/usr/local/bin/start-nxos``:
+
+   - Sources ``/etc/hotstack-nxos/image-config`` and ``config``
+   - Creates macvtap interfaces via ``ip link``
+   - Creates overlay disk via ``qemu-img create`` (skipped if exists)
+   - Opens ``/dev/tapN`` FDs and execs into ``qemu-kvm``
+
+3. **QEMU/KVM** runs the NXOS switch:
+
+   - NXOS boots with GNS3 OVMF firmware
+   - ``mgmt0`` gets DHCP from OpenStack (with POAP options 66/67)
+   - Data ports are available as ``Ethernet1/1``, ``Ethernet1/2``, etc.
+
+4. **nxos-console.service** connects to the serial console
+   (``telnet localhost:55001``) and streams NXOS output to journald.
+
+Troubleshooting
+===============
+
+Check service status::
+
+  systemctl status nxos.service
+  journalctl -u nxos.service -f
+
+View live NXOS console output::
+
+  journalctl -u nxos-console.service -f
+
+Check macvtap interfaces::
+
+  ip link show type macvtap
+
+Access the NXOS console interactively via telnet::
+
+  telnet localhost 55001
+
+Verify QEMU process::
+
+  ps aux | grep qemu-kvm

--- a/images/dib/elements/hotstack-nxos/element-deps
+++ b/images/dib/elements/hotstack-nxos/element-deps
@@ -1,0 +1,1 @@
+package-installs

--- a/images/dib/elements/hotstack-nxos/extra-data.d/10-verify-images
+++ b/images/dib/elements/hotstack-nxos/extra-data.d/10-verify-images
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+if [ -z "${DIB_NXOS_IMAGE:-}" ]; then
+    echo "ERROR: DIB_NXOS_IMAGE environment variable is not set"
+    exit 1
+fi
+
+if [ ! -f "${DIB_NXOS_IMAGE}" ]; then
+    echo "ERROR: NXOS image file not found: ${DIB_NXOS_IMAGE}"
+    exit 1
+fi
+
+echo "INFO: NXOS image verified: ${DIB_NXOS_IMAGE}"

--- a/images/dib/elements/hotstack-nxos/extra-data.d/11-copy-nxos-image
+++ b/images/dib/elements/hotstack-nxos/extra-data.d/11-copy-nxos-image
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+mkdir -p "${TMP_HOOKS_PATH}"
+cp "${DIB_NXOS_IMAGE}" "${TMP_HOOKS_PATH}/nxos.qcow2"
+
+echo "INFO: NXOS image copied to ${TMP_HOOKS_PATH}/nxos.qcow2"

--- a/images/dib/elements/hotstack-nxos/extra-data.d/12-download-firmware
+++ b/images/dib/elements/hotstack-nxos/extra-data.d/12-download-firmware
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# NXOS v64.10.x requires GNS3's custom OVMF firmware to boot.
+# The standard OVMF from the distro does not work with NXOS.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+OVMF_URL="${DIB_NXOS_OVMF_URL:-https://sourceforge.net/projects/gns-3/files/Qemu%20Appliances/OVMF-edk2-stable202305.fd.zip/download}"
+OVMF_ZIP="${TMP_HOOKS_PATH}/OVMF-edk2-stable202305.fd.zip"
+OVMF_FD="${TMP_HOOKS_PATH}/OVMF-edk2-stable202305.fd"
+
+mkdir -p "${TMP_HOOKS_PATH}"
+
+if [ ! -f "${OVMF_FD}" ]; then
+    curl -fSL -o "${OVMF_ZIP}" "${OVMF_URL}"
+    unzip -o -d "${TMP_HOOKS_PATH}" "${OVMF_ZIP}"
+    rm -f "${OVMF_ZIP}"
+
+    if [ ! -f "${OVMF_FD}" ]; then
+        echo "ERROR: Expected firmware file not found after extraction: ${OVMF_FD}"
+        ls -la "${TMP_HOOKS_PATH}"
+        exit 1
+    fi
+fi
+
+echo "INFO: GNS3 OVMF firmware ready: ${OVMF_FD}"

--- a/images/dib/elements/hotstack-nxos/install.d/50-install-nxos
+++ b/images/dib/elements/hotstack-nxos/install.d/50-install-nxos
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+NXOS_QCOW2="/tmp/in_target.d/nxos.qcow2"
+OVMF_FD="/tmp/in_target.d/OVMF-edk2-stable202305.fd"
+
+NXOS_DEST="/opt/nxos"
+OVMF_DEST="/usr/local/share/edk2/ovmf"
+
+mkdir -p "${NXOS_DEST}" "${OVMF_DEST}" /etc/hotstack-nxos
+
+cp "${NXOS_QCOW2}" "${NXOS_DEST}/nxos.qcow2"
+cp "${OVMF_FD}" "${OVMF_DEST}/OVMF-edk2-stable202305.fd"
+
+cat > /etc/hotstack-nxos/image-config <<EOF
+NXOS_QCOW2=${NXOS_DEST}/nxos.qcow2
+OVMF_FIRMWARE=${OVMF_DEST}/OVMF-edk2-stable202305.fd
+EOF

--- a/images/dib/elements/hotstack-nxos/package-installs.yaml
+++ b/images/dib/elements/hotstack-nxos/package-installs.yaml
@@ -1,0 +1,11 @@
+---
+bash-completion:
+iproute:
+jq:
+nmap-ncat:
+nmstate:
+python3-jinja2:
+qemu-kvm:
+tcpdump:
+telnet:
+vim-enhanced:

--- a/images/dib/elements/hotstack-nxos/post-install.d/80-enable-services
+++ b/images/dib/elements/hotstack-nxos/post-install.d/80-enable-services
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eu -o pipefail
+
+if [ "${DIB_DEBUG_TRACE:-0}" -gt 0 ]; then
+    set -x
+fi
+
+systemctl enable nxos.service
+systemctl enable nxos-console.service

--- a/images/dib/elements/hotstack-nxos/static/etc/NetworkManager/conf.d/99-unmanage-switch-ports.conf
+++ b/images/dib/elements/hotstack-nxos/static/etc/NetworkManager/conf.d/99-unmanage-switch-ports.conf
@@ -1,0 +1,21 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Prevent NetworkManager from managing switch data interfaces
+# Only eth0 should be managed for host management access
+# All other interfaces (eth1+) are used for macvtap passthrough to the NXOS VM
+
+[keyfile]
+unmanaged-devices=interface-name:~eth*;except:interface-name:=eth0

--- a/images/dib/elements/hotstack-nxos/static/etc/cloud/cloud.cfg.d/99-disable-switch-network-config.cfg
+++ b/images/dib/elements/hotstack-nxos/static/etc/cloud/cloud.cfg.d/99-disable-switch-network-config.cfg
@@ -1,0 +1,22 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Prevent cloud-init from auto-configuring network interfaces
+# This disables cloud-init's network configuration module entirely
+# The host will still get eth0 configured via DHCP from the base image
+# All other interfaces (eth1+) are set up by start-nxos for macvtap passthrough
+
+network:
+  config: disabled

--- a/images/dib/elements/hotstack-nxos/static/etc/hotstack-nxos/README
+++ b/images/dib/elements/hotstack-nxos/static/etc/hotstack-nxos/README
@@ -1,0 +1,21 @@
+This directory contains NXOS runtime configuration files.
+
+Files in this directory:
+- config: Runtime configuration for the NXOS nested KVM switch
+- image-config: Image paths set at build time (NXOS_QCOW2, OVMF_FIRMWARE)
+
+The config file is populated by cloud-init user-data during instance boot.
+
+Supported config variables:
+  MGMT_INTERFACE       Host management interface (default: eth0)
+  SWITCH_INTERFACE_START  First switch data interface (default: eth1)
+  SWITCH_INTERFACE_COUNT  Number of switch data interfaces (default: 4)
+  NXOS_RAM             RAM for the NXOS VM in MB (default: 8192)
+  NXOS_VCPUS           vCPUs for the NXOS VM (default: 2)
+  CONSOLE_PORT         Telnet console port (default: 55001)
+
+Interface mapping:
+  eth0  = Host management (CentOS, NM-managed, DHCP)
+  eth1  = NXOS mgmt0 (macvtap passthrough)
+  eth2  = NXOS Ethernet1/1 (macvtap, trunk port)
+  eth3+ = NXOS Ethernet1/2+ (macvtap, access ports)

--- a/images/dib/elements/hotstack-nxos/static/etc/systemd/system/nxos-console.service
+++ b/images/dib/elements/hotstack-nxos/static/etc/systemd/system/nxos-console.service
@@ -1,0 +1,28 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+[Unit]
+Description=NXOS Console Logger
+After=nxos.service
+BindsTo=nxos.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ncat --recv-only localhost 55001
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/images/dib/elements/hotstack-nxos/static/etc/systemd/system/nxos.service
+++ b/images/dib/elements/hotstack-nxos/static/etc/systemd/system/nxos.service
@@ -1,0 +1,32 @@
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+[Unit]
+Description=NXOS Nested KVM Switch
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/usr/local/bin/start-nxos
+ConditionPathExists=/etc/hotstack-nxos/config
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/start-nxos
+KillMode=process
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/images/dib/elements/hotstack-nxos/static/usr/local/bin/start-nxos
+++ b/images/dib/elements/hotstack-nxos/static/usr/local/bin/start-nxos
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Copyright Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# NXOS Nested KVM Switch Startup Script
+#
+# Creates macvtap interfaces for L2 passthrough, prepares a QEMU disk
+# overlay, opens /dev/tapN file descriptors, and execs into qemu-kvm.
+# Invoked by nxos.service (Type=simple) -- systemd manages the QEMU
+# process directly.
+
+set -euo pipefail
+
+CONFIG_FILE="/etc/hotstack-nxos/config"
+IMAGE_CONFIG="/etc/hotstack-nxos/image-config"
+WORK_DIR="/var/lib/hotstack-nxos"
+
+MGMT_INTERFACE="eth0"
+SWITCH_INTERFACE_START="eth1"
+SWITCH_INTERFACE_COUNT=4
+NXOS_RAM=8192
+NXOS_VCPUS=4
+CONSOLE_PORT=55001
+
+log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [start-nxos] $*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# -------------------------------------------------------------------
+# Load configuration
+# -------------------------------------------------------------------
+
+[[ -f "${IMAGE_CONFIG}" ]] || die "Image config not found: ${IMAGE_CONFIG}"
+# shellcheck source=/dev/null
+source "${IMAGE_CONFIG}"
+
+[[ -f "${CONFIG_FILE}" ]] || die "Config not found: ${CONFIG_FILE}"
+# shellcheck source=/dev/null
+source "${CONFIG_FILE}"
+
+[[ -f "${NXOS_QCOW2}" ]] || die "NXOS base image not found: ${NXOS_QCOW2}"
+[[ -f "${OVMF_FIRMWARE}" ]] || die "OVMF firmware not found: ${OVMF_FIRMWARE}"
+
+log "Configuration:"
+log "  MGMT_INTERFACE=${MGMT_INTERFACE}"
+log "  SWITCH_INTERFACE_START=${SWITCH_INTERFACE_START}"
+log "  SWITCH_INTERFACE_COUNT=${SWITCH_INTERFACE_COUNT}"
+log "  NXOS_RAM=${NXOS_RAM} NXOS_VCPUS=${NXOS_VCPUS}"
+log "  CONSOLE_PORT=${CONSOLE_PORT}"
+log "  NXOS_QCOW2=${NXOS_QCOW2}"
+log "  OVMF_FIRMWARE=${OVMF_FIRMWARE}"
+
+mkdir -p "${WORK_DIR}"
+
+# -------------------------------------------------------------------
+# Parse interface names
+# -------------------------------------------------------------------
+
+IFACE_BASE="${SWITCH_INTERFACE_START%%[0-9]*}"
+IFACE_NUM="${SWITCH_INTERFACE_START##*[!0-9]}"
+
+# -------------------------------------------------------------------
+# Create macvtap interfaces
+# -------------------------------------------------------------------
+
+log "Creating macvtap interfaces..."
+declare -a TAP_INDICES=()
+declare -a TAP_MACS=()
+
+for ((i = 0; i < SWITCH_INTERFACE_COUNT; i++)); do
+    iface="${IFACE_BASE}$((IFACE_NUM + i))"
+    macvtap="macvtap-${iface}"
+
+    [[ -d "/sys/class/net/${iface}" ]] || die "Interface ${iface} not found"
+    mac=$(< "/sys/class/net/${iface}/address")
+
+    ip link set "${iface}" up
+
+    if [[ ! -d "/sys/class/net/${macvtap}" ]]; then
+        ip link add link "${iface}" name "${macvtap}" type macvtap mode passthru
+    fi
+    ip link set "${macvtap}" up
+
+    tap_index=$(< "/sys/class/net/${macvtap}/ifindex")
+    TAP_INDICES+=("${tap_index}")
+    TAP_MACS+=("${mac}")
+
+    log "  ${iface} (${mac}) -> ${macvtap} (tap${tap_index})"
+done
+
+# -------------------------------------------------------------------
+# Create overlay disk
+# -------------------------------------------------------------------
+
+OVERLAY_DISK="${WORK_DIR}/nxos-disk.qcow2"
+if [[ ! -f "${OVERLAY_DISK}" ]]; then
+    log "Creating overlay disk from ${NXOS_QCOW2}..."
+    qemu-img create -f qcow2 -o preallocation=metadata,extended_l2=on -b "${NXOS_QCOW2}" -F qcow2 "${OVERLAY_DISK}"
+fi
+
+# -------------------------------------------------------------------
+# Open tap device FDs and exec into qemu-kvm
+# -------------------------------------------------------------------
+
+log "Launching QEMU (exec)..."
+log "Console available at: telnet localhost ${CONSOLE_PORT}"
+
+QEMU_ARGS=(
+    -enable-kvm
+    -machine q35
+    -cpu host
+    -bios "${OVMF_FIRMWARE}"
+    -m "${NXOS_RAM}"
+    -smp "${NXOS_VCPUS}"
+    -drive "file=${OVERLAY_DISK},if=none,id=disk0,format=qcow2"
+    -device "virtio-scsi-pci,id=scsi0"
+    -device "scsi-hd,drive=disk0,bus=scsi0.0"
+)
+
+# FDs start at 3 (after stdin/stdout/stderr)
+for ((i = 0; i < SWITCH_INTERFACE_COUNT; i++)); do
+    fd=$((i + 3))
+    QEMU_ARGS+=(
+        -netdev "tap,id=net${i},fd=${fd},vhost=off"
+        -device "e1000,netdev=net${i},mac=${TAP_MACS[${i}]}"
+    )
+done
+
+QEMU_ARGS+=(
+    -serial "tcp:localhost:${CONSOLE_PORT},server,nowait"
+    -nographic
+)
+
+# Open /dev/tapN on FDs 3, 4, 5, ... then exec into qemu-kvm
+for ((i = 0; i < SWITCH_INTERFACE_COUNT; i++)); do
+    fd=$((i + 3))
+    eval "exec ${fd}<>/dev/tap${TAP_INDICES[${i}]}"
+done
+
+exec /usr/libexec/qemu-kvm "${QEMU_ARGS[@]}"

--- a/images/dib/elements/hotstack-nxos/static/usr/local/lib/hotstack-nxos/nmstate.yaml.j2
+++ b/images/dib/elements/hotstack-nxos/static/usr/local/lib/hotstack-nxos/nmstate.yaml.j2
@@ -1,0 +1,35 @@
+{# Copyright Red Hat, Inc.                                            #}
+{# All Rights Reserved.                                               #}
+{#                                                                     #}
+{# Licensed under the Apache License, Version 2.0 (the "License");    #}
+{# you may not use this file except in compliance with the License.    #}
+{# You may obtain a copy of the License at                             #}
+{#                                                                     #}
+{#     http://www.apache.org/licenses/LICENSE-2.0                      #}
+{#                                                                     #}
+{# Unless required by applicable law or agreed to in writing, software #}
+{# distributed under the License is distributed on an "AS IS" BASIS,  #}
+{# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or     #}
+{# implied. See the License for the specific language governing        #}
+{# permissions and limitations under the License.                      #}
+{#                                                                     #}
+{# Macvtap interface configuration for NXOS switch data ports.         #}
+{# Rendered by start-nxos and applied with: nmstatectl apply           #}
+---
+interfaces:
+{% for iface in interfaces %}
+  - name: {{ iface.name }}
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: {{ iface.macvtap_name }}
+    type: mac-vtap
+    state: up
+    mac-vtap:
+      base-iface: {{ iface.name }}
+      mode: passthru
+    mac-address: {{ iface.mac }}
+{% endfor %}

--- a/images/dib/nxos-image.yaml
+++ b/images/dib/nxos-image.yaml
@@ -1,0 +1,57 @@
+---
+- imagename: nxos-switch-host.qcow2
+  elements:
+    - centos
+    - vm
+    - epel
+    - growroot
+    - block-device-efi
+    - package-installs
+    - hotstack-nxos
+  environment:
+    DIB_RELEASE: '9-stream'
+    DIB_PYTHON_VERSION: '3'
+    DIB_IMAGE_SIZE: '15'
+    DIB_TIMEZONE: 'UTC'
+    COMPRESS_IMAGE: '1'
+    # DIB_NXOS_IMAGE set via Makefile (NXOS_QCOW2_IMAGE)
+    DIB_BLOCK_DEVICE_CONFIG: |
+      - local_loop:
+          name: image0
+      - partitioning:
+          base: image0
+          label: gpt
+          partitions:
+            - name: ESP
+              type: 'EF00'
+              size: 550MiB
+              mkfs:
+                type: vfat
+                mount:
+                  mount_point: /boot/efi
+                  fstab:
+                    options: "defaults"
+                    fsck-passno: 2
+            - name: BSP
+              type: 'EF02'
+              size: 8MiB
+            - name: boot
+              type: '8300'
+              size: 512MiB
+              mkfs:
+                type: xfs
+                mount:
+                  mount_point: /boot
+                  fstab:
+                    options: "defaults"
+                    fsck-passno: 1
+            - name: root
+              type: '8300'
+              size: 100%
+              mkfs:
+                type: xfs
+                mount:
+                  mount_point: /
+                  fstab:
+                    options: "defaults"
+                    fsck-passno: 1

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -205,3 +205,14 @@
       when: hotstack_git_server_enabled | bool
       ansible.builtin.include_role:
         name: hotstack_git_server
+
+    - name: Wait for dependent hosts to be reachable
+      when: wait_for_hosts | length > 0
+      ansible.builtin.wait_for:
+        host: "{{ item.host }}"
+        port: "{{ item.port }}"
+        timeout: "{{ item.timeout | default(1800) }}"
+        sleep: 10
+      loop: "{{ wait_for_hosts }}"
+      loop_control:
+        label: "{{ item.host }}:{{ item.port }}"

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/README.md
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/README.md
@@ -1,0 +1,66 @@
+# Devstack with Cisco NXOS VLAN Trunking (NETCONF OpenConfig)
+
+Single-switch topology with 1 Cisco NX-OS 9000v switch, 1 Devstack
+node, 2 Ironic nodes, and 1 controller. Uses
+networking-generic-switch with the `netconf_openconfig` driver for
+NETCONF-based switch management.
+
+The NX-OS switch runs as a nested KVM VM inside a CentOS 9
+"switch-host" image (`hotstack-nxos`), with macvtap passthrough
+for direct L2 access to OpenStack ports. Initial switch
+configuration is applied via POAP (PowerOn Auto Provisioning) --
+the controller serves `poap.py` and `poap.cfg` over TFTP so the
+switch bootstraps itself at first boot with NETCONF and OpenConfig
+enabled.
+
+## Topology
+
+Management: `192.168.32.0/24` | VLANs: 100-105 | MTU: 1500
+
+## Deployment
+
+Deploy the scenario:
+
+```bash
+ansible-playbook \
+  -e @scenarios/networking-lab/devstack-nxos-vlan-netconf/bootstrap_vars.yml \
+  -e os_cloud=<cloud-name> \
+  bootstrap_devstack.yml
+```
+
+## Accessing
+
+Access the switch and devstack nodes via SSH from the controller.
+
+```bash
+# Switch host (CentOS wrapper VM)
+ssh cloud-user@switch.stack.lab
+
+# Switch console (from the switch host)
+telnet localhost 55001
+
+# Switch via SSH (after POAP completes)
+ssh admin@switch.stack.lab
+
+# Devstack
+ssh stack@devstack.stack.lab
+```
+
+## POAP Bootstrap
+
+The controller runs a TFTP server (dnsmasq) that serves the POAP
+payload to the switch management interface (`mgmt0`). On first
+boot NX-OS fetches `poap.py` which in turn downloads and applies
+`poap.cfg`. The POAP config enables:
+
+- `feature netconf` and `feature openconfig` for NGS management
+- Trunk port `Ethernet1/1` (connected to the devstack trunk)
+- Access ports `Ethernet1/2`, `Ethernet1/3` (ironic nodes)
+- Management interface with DHCP
+
+## NGS Configuration
+
+networking-generic-switch is configured with the
+`netconf_openconfig` device type and `device_params = name:nexus`
+for NX-OS NETCONF compatibility. VLAN membership on trunk and
+access ports is managed dynamically by NGS.

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/automation-vars.yml
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/automation-vars.yml
@@ -1,0 +1,65 @@
+---
+stages:
+  - name: Enroll nodes in devstack ironic
+    documentation: >-
+      Registers physical baremetal nodes with the Ironic service in the DevStack
+      deployment using the node definitions from ironic_nodes.yaml. This creates
+      Ironic node records with BMC access credentials, hardware profiles, and port
+      configurations for networking-generic-switch integration.
+    shell: |
+      set -xe -o pipefail
+
+      NODES_FILE=/home/zuul/data/ironic_nodes.yaml
+
+      # Enroll the nodes
+      openstack --os-cloud devstack-admin baremetal create "$NODES_FILE"
+
+      echo "Nodes enrolled successfully"
+      openstack --os-cloud devstack-admin baremetal node list
+
+  - name: Wait for ironic nodes to reach enroll state
+    documentation: >-
+      Monitors node state transition to 'enroll' status, indicating that Ironic
+      has successfully registered the nodes and validated basic BMC connectivity.
+      This is the first state in the baremetal provisioning lifecycle.
+    shell: |
+      set -xe -o pipefail
+
+      counter=0
+      max_retries=60
+      sleep_interval=5
+
+      echo "Waiting for all nodes to reach 'enroll' state..."
+
+      until ! openstack --os-cloud devstack-admin baremetal node list -f value -c "Provisioning State" | grep -v "enroll"; do
+        ((counter++))
+        if (( counter > max_retries )); then
+          echo "ERROR: Timeout waiting for nodes to reach enroll state"
+          openstack --os-cloud devstack-admin baremetal node list
+          exit 1
+        fi
+        echo "Attempt $counter/$max_retries - waiting ${sleep_interval}s..."
+        sleep ${sleep_interval}
+      done
+
+      echo "All nodes successfully reached enroll state"
+      openstack --os-cloud devstack-admin baremetal node list
+
+  - name: Manage nodes
+    documentation: >-
+      Transitions nodes from 'enroll' to 'manageable' state. This validates
+      basic hardware connectivity and prepares nodes for further operations.
+    shell: |
+      set -x -o pipefail
+
+      # Get list of node UUIDs
+      node_uuids=$(openstack --os-cloud devstack-admin baremetal node list -f value -c UUID)
+
+      # Manage each node with --wait (300 second timeout)
+      for uuid in $node_uuids; do
+        echo "Managing node: $uuid"
+        openstack --os-cloud devstack-admin baremetal node manage --wait 300 $uuid
+      done
+
+      echo "All nodes successfully reached manageable state"
+      openstack --os-cloud devstack-admin baremetal node list

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/bootstrap_vars.yml
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/bootstrap_vars.yml
@@ -1,0 +1,46 @@
+---
+# Bootstrap configuration for devstack-nxos-vlan-netconf scenario
+
+# OpenStack cloud configuration
+os_cloud: default
+os_floating_network: public
+os_router_external_network: public
+
+# Scenario configuration
+scenario: devstack-nxos-vlan-netconf
+scenario_dir: scenarios/networking-lab
+stack_template_path: "{{ scenario_dir }}/{{ scenario }}/heat_template.yaml"
+automation_vars_file: "{{ scenario_dir }}/{{ scenario }}/automation-vars.yml"
+
+# DNS and NTP
+ntp_servers: []
+dns_servers:
+  - 8.8.8.8
+  - 8.8.4.4
+
+# Stack naming
+stack_name: "hs-{{ scenario | replace('/', '-') }}-{{ zuul.build[:8] | default('no-zuul') }}"
+
+# Stack parameters
+stack_parameters:
+  dns_servers: "{{ dns_servers }}"
+  ntp_servers: "{{ ntp_servers }}"
+  controller_ssh_pub_key: "{{ controller_ssh_pub_key | default('') }}"
+  dataplane_ssh_pub_key: "{{ dataplane_ssh_pub_key | default('') }}"
+  router_external_network: "{{ os_router_external_network | default('public') }}"
+  floating_ip_network: "{{ os_floating_network | default('public') }}"
+  controller_params:
+    image: hotstack-controller
+    flavor: hotstack.small
+  devstack_params:
+    image: ubuntu-noble-server
+    flavor: hotstack.large
+  switch_params:
+    image: hotstack-nxos
+    flavor: hotstack.xlarge
+  ironic_params:
+    image: CentOS-Stream-GenericCloud-9
+    flavor: hotstack.medium
+
+# Controller role configuration
+controller_install_openstack_client: true

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/heat_template.yaml
@@ -1,0 +1,780 @@
+---
+heat_template_version: rocky
+
+description: >
+  Heat template for networking lab with single NXOS switch (nested KVM)
+  using VLAN trunking and NETCONF OpenConfig. NXOS bootstraps via POAP from a
+  TFTP server on the controller. Includes 1 switch, 1 devstack node, and 2
+  ironic nodes.
+
+parameters:
+  dns_servers:
+    type: comma_delimited_list
+    default:
+      - 8.8.8.8
+      - 8.8.4.4
+  ntp_servers:
+    type: comma_delimited_list
+    default: []
+  controller_ssh_pub_key:
+    type: string
+  dataplane_ssh_pub_key:
+    type: string
+  router_external_network:
+    type: string
+    default: public
+  floating_ip_network:
+    type: string
+    default: public
+  net_value_specs:
+    type: json
+    default: {}
+
+  controller_params:
+    type: json
+    default:
+      image: hotstack-controller
+      flavor: hotstack.small
+  devstack_params:
+    type: json
+    default:
+      image: ubuntu-noble-server
+      flavor: hotstack.large
+  ironic_params:
+    type: json
+    default:
+      image: CentOS-Stream-GenericCloud-9
+      flavor: hotstack.medium
+  switch_params:
+    type: json
+    default:
+      image: hotstack-nxos
+      flavor: hotstack.xlarge
+  cdrom_disk_bus:
+    type: string
+    description: >
+      Disk bus type for CDROM device. 'sata' may be required for older versions
+      of OpenStack. Heat patch https://review.opendev.org/c/openstack/heat/+/966688
+      is needed for 'sata' support.
+    default: scsi
+    constraints:
+      - allowed_values:
+          - sata
+          - scsi
+
+resources:
+  #
+  # Networks
+  #
+  machine-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  # Simple bridge networks for server attachments
+  devstack-br-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  ironic0-br-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  ironic1-br-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  trunk-net:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  tenant-vlan103:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  tenant-vlan104:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  tenant-vlan105:
+    type: OS::Neutron::Net
+    properties:
+      port_security_enabled: false
+      value_specs: {get_param: net_value_specs}
+
+  #
+  # Subnets
+  #
+  machine-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: machine-net}
+      ip_version: 4
+      cidr: 192.168.32.0/24
+      enable_dhcp: true
+      dns_nameservers:
+        - 192.168.32.254
+
+  devstack-br-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: devstack-br-net}
+      ip_version: 4
+      cidr: 172.20.10.0/29
+      enable_dhcp: false
+      gateway_ip: null
+
+  ironic0-br-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: ironic0-br-net}
+      ip_version: 4
+      cidr: 172.20.11.0/29
+      enable_dhcp: false
+      gateway_ip: null
+
+  ironic1-br-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: ironic1-br-net}
+      ip_version: 4
+      cidr: 172.20.12.0/29
+      enable_dhcp: false
+      gateway_ip: null
+
+  trunk-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: trunk-net}
+      ip_version: 4
+      cidr: 172.20.2.0/24
+      enable_dhcp: false
+      gateway_ip: null
+
+  tenant-vlan103-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: tenant-vlan103}
+      ip_version: 4
+      cidr: 172.20.3.0/24
+      enable_dhcp: false
+      gateway_ip: null
+
+  tenant-vlan104-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: tenant-vlan104}
+      ip_version: 4
+      cidr: 172.20.4.0/24
+      enable_dhcp: false
+      gateway_ip: null
+
+  tenant-vlan105-subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      network: {get_resource: tenant-vlan105}
+      ip_version: 4
+      cidr: 172.20.5.0/24
+      enable_dhcp: false
+      gateway_ip: null
+
+  #
+  # Routers
+  #
+  router:
+    type: OS::Neutron::Router
+    properties:
+      admin_state_up: true
+      external_gateway_info:
+        network: {get_param: router_external_network}
+
+  machine-net-router-interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: router}
+      subnet: {get_resource: machine-subnet}
+
+  #
+  # Controller Instance
+  #
+  controller_users:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        users:
+          - default
+          - name: zuul
+            gecos: "Zuul user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+
+  controller-write-files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+          - path: /etc/dnsmasq.conf
+            content: |
+              # dnsmasq service config
+              # Include all files in /etc/dnsmasq.d except RPM backup files
+              conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig
+              no-resolv
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/forwarders.conf
+            content:
+              str_replace:
+                template: |
+                  # DNS forwarders records
+                  server=$dns1
+                  server=$dns2
+                params:
+                  $dns1: {get_param: [dns_servers, 0]}
+                  $dns2: {get_param: [dns_servers, 1]}
+            owner: root:dnsmasq
+          - path: /etc/dnsmasq.d/host_records.conf
+            content:
+              str_replace:
+                template: |
+                  # Host records
+                  host-record=controller-0.stack.lab,$controller0
+                  host-record=switch-host.stack.lab,$switch_host
+                  host-record=switch.stack.lab,$switch
+                  host-record=devstack.stack.lab,$devstack
+                params:
+                  $controller0: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+                  $switch_host: {get_attr: [switch-machine-port, fixed_ips, 0, ip_address]}
+                  $switch: {get_attr: [switch-switch-mgmt-port, fixed_ips, 0, ip_address]}
+                  $devstack: {get_attr: [devstack-machine-port, fixed_ips, 0, ip_address]}
+            owner: root:dnsmasq
+          - path: /etc/resolv.conf
+            content: |
+              nameserver: 127.0.0.1
+            owner: root:root
+          - path: /etc/NetworkManager/conf.d/98-rc-manager.conf
+            content: |
+              [main]
+              rc-manager=unmanaged
+            owner: root:root
+          - path: /etc/dnsmasq.d/tftpboot.conf
+            content: |
+              enable-tftp
+              tftp-root=/var/lib/tftpboot
+              tftp-mtu=1442
+            owner: root:root
+          - path: /var/lib/tftpboot/poap.py
+            content: {get_file: poap.py}
+            owner: root:root
+          - path: /var/lib/tftpboot/poap.cfg
+            content: {get_file: poap.cfg}
+            owner: root:root
+
+  controller-runcmd:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        runcmd:
+          - ['setenforce', 'permissive']
+          - ['sed', '-i', 's/Listen 80/Listen 8081/g', '/etc/httpd/conf/httpd.conf']
+          - ['systemctl', 'enable', 'httpd.service']
+          - ['systemctl', 'start', 'httpd.service']
+          - ['systemctl', 'enable', 'dnsmasq.service']
+          - ['systemctl', 'start', 'dnsmasq.service']
+
+  controller-init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: {get_resource: controller_users}
+        - config: {get_resource: controller-write-files}
+        - config: {get_resource: controller-runcmd}
+
+  controller-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      mac_address: "fa:16:9e:81:f6:05"
+      fixed_ips:
+        - ip_address: 192.168.32.254
+
+  controller-floating-ip:
+    depends_on: machine-net-router-interface
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: floating_ip_network}
+      port_id: {get_resource: controller-machine-port}
+
+  controller:
+    type: OS::Nova::Server
+    properties:
+      image: {get_param: [controller_params, image]}
+      flavor: {get_param: [controller_params, flavor]}
+      networks:
+        - port: {get_resource: controller-machine-port}
+      user_data_format: RAW
+      user_data: {get_resource: controller-init}
+
+  #
+  # NXOS Switch (nested KVM on CentOS 9 host)
+  #
+  # NIC mapping:
+  #   eth0 = Host management (CentOS, NM-managed, DHCP)
+  #   eth1 = NXOS mgmt0 (macvtap passthrough, POAP DHCP)
+  #   eth2 = NXOS Ethernet1/1 (macvtap, trunk port)
+  #   eth3 = NXOS Ethernet1/2 (macvtap, ironic0 access port)
+  #   eth4 = NXOS Ethernet1/3 (macvtap, ironic1 access port)
+  #
+  switch-init:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        hostname: switch-host
+        fqdn: switch-host.stack.lab
+        users:
+          - default
+          - name: zuul
+            gecos: "Zuul user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+              - {get_param: dataplane_ssh_pub_key}
+        write_files:
+          - path: /etc/hotstack-nxos/config
+            content: |
+              MGMT_INTERFACE=eth0
+              SWITCH_INTERFACE_START=eth1
+              SWITCH_INTERFACE_COUNT=4
+              NXOS_RAM=8192
+              NXOS_VCPUS=2
+              CONSOLE_PORT=55001
+            owner: root:root
+            permissions: '0644'
+        runcmd:
+          - systemctl start nxos.service
+
+  switch-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:01"
+      fixed_ips:
+        - ip_address: 192.168.32.11
+
+  switch-extra-dhcp-opts-value:
+    type: OS::Heat::Value
+    properties:
+      type: json
+      value:
+        extra_dhcp_opts:
+          - opt_name: "66"
+            opt_value:
+              str_replace:
+                template: "$server_address"
+                params:
+                  $server_address: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+            ip_version: 4
+          - opt_name: "67"
+            opt_value: "poap.py"
+            ip_version: 4
+
+  switch-switch-mgmt-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:10"
+      fixed_ips:
+        - ip_address: 192.168.32.111
+      value_specs: {get_attr: [switch-extra-dhcp-opts-value, value]}
+
+  switch-trunk-parent-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: trunk-net}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:02"
+
+  switch-trunk-tenant-vlan103-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan103}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:03"
+
+  switch-trunk-tenant-vlan104-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan104}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:04"
+
+  switch-trunk-tenant-vlan105-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan105}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:05"
+
+  switch-trunk:
+    type: OS::Neutron::Trunk
+    properties:
+      port: {get_resource: switch-trunk-parent-port}
+      sub_ports:
+        - port: {get_resource: switch-trunk-tenant-vlan103-port}
+          segmentation_id: 103
+          segmentation_type: vlan
+        - port: {get_resource: switch-trunk-tenant-vlan104-port}
+          segmentation_id: 104
+          segmentation_type: vlan
+        - port: {get_resource: switch-trunk-tenant-vlan105-port}
+          segmentation_id: 105
+          segmentation_type: vlan
+
+  switch-ironic0-br-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ironic0-br-net}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:06"
+
+  switch-ironic1-br-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ironic1-br-net}
+      port_security_enabled: false
+      mac_address: "22:57:f8:dd:01:07"
+
+  switch:
+    type: OS::Nova::Server
+    depends_on: switch-trunk
+    properties:
+      image: {get_param: [switch_params, image]}
+      flavor: {get_param: [switch_params, flavor]}
+      config_drive: false
+      networks:
+        - port: {get_resource: switch-machine-port}
+        - port: {get_resource: switch-switch-mgmt-port}
+        - port: {get_attr: [switch-trunk, port_id]}
+        - port: {get_resource: switch-ironic0-br-port}
+        - port: {get_resource: switch-ironic1-br-port}
+      user_data_format: RAW
+      user_data: {get_resource: switch-init}
+
+  #
+  # Devstack Instance
+  #
+  devstack_users:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        users:
+          - default
+          - name: stack
+            gecos: "Stack user"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            homedir: /opt/stack
+            shell: /bin/bash
+            ssh_authorized_keys:
+              - {get_param: controller_ssh_pub_key}
+              - {get_param: dataplane_ssh_pub_key}
+
+  devstack-network-config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        hostname: devstack
+        fqdn: devstack.stack.lab
+
+  devstack-write-files:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        write_files:
+          - path: /etc/hotstack/local.conf.j2
+            content:
+              get_file: local.conf.j2
+            owner: root:root
+            permissions: '0644'
+
+  devstack-init:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+        - config: {get_resource: devstack_users}
+        - config: {get_resource: devstack-network-config}
+        - config: {get_resource: devstack-write-files}
+
+  devstack-machine-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: machine-net}
+      port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:20"
+      fixed_ips:
+        - ip_address: 192.168.32.20
+
+  devstack-trunk-parent-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: trunk-net}
+      port_security_enabled: false
+      mac_address: "fa:16:9e:81:f6:21"
+
+  devstack-tenant-vlan103-subport:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan103}
+      port_security_enabled: false
+
+  devstack-tenant-vlan104-subport:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan104}
+      port_security_enabled: false
+
+  devstack-tenant-vlan105-subport:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: tenant-vlan105}
+      port_security_enabled: false
+
+  devstack-trunk:
+    type: OS::Neutron::Trunk
+    properties:
+      port: {get_resource: devstack-trunk-parent-port}
+      sub_ports:
+        - port: {get_resource: devstack-tenant-vlan103-subport}
+          segmentation_id: 103
+          segmentation_type: vlan
+        - port: {get_resource: devstack-tenant-vlan104-subport}
+          segmentation_id: 104
+          segmentation_type: vlan
+        - port: {get_resource: devstack-tenant-vlan105-subport}
+          segmentation_id: 105
+          segmentation_type: vlan
+
+  devstack:
+    type: OS::Nova::Server
+    depends_on: devstack-trunk
+    properties:
+      image: {get_param: [devstack_params, image]}
+      flavor: {get_param: [devstack_params, flavor]}
+      networks:
+        - port: {get_resource: devstack-machine-port}
+        - port: {get_attr: [devstack-trunk, port_id]}
+      user_data_format: RAW
+      user_data: {get_resource: devstack-init}
+
+  #
+  # Ironic Nodes
+  #
+  ironic0-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ironic0-br-net}
+      port_security_enabled: false
+
+  ironic0:
+    type: OS::Nova::Server
+    properties:
+      flavor: {get_param: [ironic_params, flavor]}
+      image: {get_param: [ironic_params, image]}
+      networks:
+        - port: {get_resource: ironic0-port}
+
+  ironic1-port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: ironic1-br-net}
+      port_security_enabled: false
+
+  ironic1:
+    type: OS::Nova::Server
+    properties:
+      flavor: {get_param: [ironic_params, flavor]}
+      image: {get_param: [ironic_params, image]}
+      networks:
+        - port: {get_resource: ironic1-port}
+
+outputs:
+  wait_for_hosts:
+    description: >
+      List of hosts and ports to wait for before proceeding with deployment.
+      Used by the controller role to block until slow-booting services are ready.
+    value:
+      - host: switch.stack.lab
+        port: 830
+        timeout: 1800
+
+  controller_floating_ip:
+    description: Controller Floating IP
+    value: {get_attr: [controller-floating-ip, floating_ip_address]}
+
+  controller_ansible_host:
+    description: >
+      Controller ansible host, this struct can be passed to the ansible.builtin.add_host module
+    value:
+      name: controller-0
+      ansible_ssh_user: zuul
+      ansible_host: {get_attr: [controller-floating-ip, floating_ip_address]}
+      ansible_port: 22
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+      groups: controllers
+
+  devstack_ansible_host:
+    description: >
+      Devstack ansible host, this struct can be passed to the ansible.builtin.add_host module.
+      Uses ProxyJump through the controller for SSH access.
+    value:
+      name: devstack
+      ansible_user: stack
+      ansible_host: {get_attr: [devstack-machine-port, fixed_ips, 0, ip_address]}
+      ansible_port: 22
+      ansible_ssh_common_args:
+        str_replace:
+          template: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ProxyJump=zuul@$controller_ip'
+          params:
+            $controller_ip: {get_attr: [controller-floating-ip, floating_ip_address]}
+      ansible_ssh_private_key_file: '~/.ssh/id_rsa'
+      groups: devstack_nodes
+
+  devstack_netplan_config:
+    description: >
+      Complete netplan configuration for devstack node to be written by Ansible
+    value:
+      network:
+        version: 2
+        ethernets:
+          enp3s0:
+            match:
+              macaddress: "fa:16:9e:81:f6:20"
+            dhcp4: true
+            set-name: "enp3s0"
+            mtu: 1500
+          enp4s0:
+            match:
+              macaddress: "fa:16:9e:81:f6:21"
+            dhcp4: false
+            dhcp6: false
+            set-name: trunk0
+            mtu: 1500
+
+  sushy_emulator_uuids:
+    description: UUIDs of instances to manage with sushy-tools - RedFish virtual BMC
+    value:
+      ironic0: {get_resource: ironic0}
+      ironic1: {get_resource: ironic1}
+
+  sushy_tools_vmedia_type:
+    description: Virtual media implementation type for sushy-tools (rescue or volumeRebuild)
+    value: rescue
+
+  ironic_nodes:
+    description: Ironic nodes YAML, used with openstack baremetal create to enroll nodes in Openstack Ironic
+    value:
+      nodes:
+        - name: ironic0
+          driver: redfish
+          bios_interface: no-bios
+          boot_interface: redfish-virtual-media
+          network_interface: neutron
+          driver_info:
+            redfish_address: http://controller-0.stack.lab:8000
+            redfish_system_id:
+              str_replace:
+                template: "/redfish/v1/Systems/$SYS_ID"
+                params:
+                  $SYS_ID: {get_resource: ironic0}
+            redfish_username: admin
+            redfish_password: password
+          properties:
+            cpu_arch: x86_64
+            cpus: 1
+            memory_mb: 1024
+            local_gb: 15
+            capabilities: boot_mode:uefi
+          ports:
+            - address: {get_attr: [ironic0-port, mac_address]}
+              physical_network: public
+              local_link_connection:
+                switch_info: switch.stack.lab
+                switch_id: "22:57:f8:dd:01:10"
+                port_id: "eth1/2"
+        - name: ironic1
+          driver: redfish
+          bios_interface: no-bios
+          boot_interface: redfish-virtual-media
+          network_interface: neutron
+          driver_info:
+            redfish_address: http://controller-0.stack.lab:8000
+            redfish_system_id:
+              str_replace:
+                template: "/redfish/v1/Systems/$SYS_ID"
+                params:
+                  $SYS_ID: {get_resource: ironic1}
+            redfish_username: admin
+            redfish_password: password
+          properties:
+            cpu_arch: x86_64
+            cpus: 1
+            memory_mb: 1024
+            local_gb: 15
+            capabilities: boot_mode:uefi
+          ports:
+            - address: {get_attr: [ironic1-port, mac_address]}
+              physical_network: public
+              local_link_connection:
+                switch_info: switch.stack.lab
+                switch_id: "22:57:f8:dd:01:10"
+                port_id: "eth1/3"
+
+  ansible_inventory:
+    description: Ansible inventory
+    value:
+      all:
+        children:
+          controllers:
+            vars:
+          switches:
+            vars:
+          devstack_nodes:
+            vars:
+      localhosts:
+        hosts:
+          localhost:
+            ansible_connection: local
+      controllers:
+        hosts:
+          controller0:
+            ansible_host: {get_attr: [controller-machine-port, fixed_ips, 0, ip_address]}
+            ansible_user: zuul
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
+      switches:
+        hosts:
+          switch:
+            ansible_host: {get_attr: [switch-machine-port, fixed_ips, 0, ip_address]}
+            ansible_user: zuul
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+            ansible_ssh_private_key_file: '~/.ssh/id_rsa'
+      devstack_nodes:
+        hosts:
+          devstack:
+            ansible_host: {get_attr: [devstack-machine-port, fixed_ips, 0, ip_address]}
+            ansible_user: stack
+            ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+            ansible_ssh_private_key_file: '~/.ssh/id_rsa'

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/local.conf.j2
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/local.conf.j2
@@ -101,8 +101,12 @@ OVN_BRIDGE_MAPPINGS=public:br-ex
 # Enable Ironic
 enable_plugin ironic https://opendev.org/openstack/ironic
 
+# Enable etcd3 for tooz coordination (DLM) in networking-generic-switch
+enable_service etcd3
+GENERIC_SWITCH_USER_MAX_SESSIONS=1
+
 # Enable networking-generic-switch plugin
-enable_plugin networking-generic-switch https://opendev.org/openstack/networking-generic-switch refs/changes/62/990062/8
+enable_plugin networking-generic-switch https://opendev.org/openstack/networking-generic-switch refs/changes/62/990062/6
 
 # Enable networking-baremetal plugin
 enable_plugin networking-baremetal https://opendev.org/openstack/networking-baremetal
@@ -135,11 +139,10 @@ device_type = netconf_openconfig
 host = switch.stack.lab
 port = 830
 username = admin
-password = admin
+password = password
 hostkey_verify = false
-ngs_mac_address = 22:57:f8:dd:01:01
+device_params = name:nexus
+ngs_mac_address = 22:57:f8:dd:01:10
 ngs_physical_networks = public
-ngs_trunk_ports = Ethernet1
-ngs_netconf_target = running
-ngs_save_configuration = true
-ngs_netconf_save_config = <config><commands xmlns="http://arista.com/yang/cli"><command>write memory</command></commands></config>
+ngs_trunk_ports = eth1/1
+ngs_max_connections = 1

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/manage-poap-md5sum.sh
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/manage-poap-md5sum.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Script to manage POAP md5sum around black formatting
+# This script: removes md5sum -> runs black -> restores md5sum
+
+set -e
+
+cd "$(dirname "$0")"
+f=poap.py
+
+# Step 1: Remove the md5sum line
+sed -i '/^# *md5sum=/d' "$f"
+
+# Step 2: Restore and update the md5sum line
+# Insert the md5sum line after the shebang (line 2)
+sed -i '1a\#md5sum="placeholder"' "$f"
+
+# Generate new md5sum excluding the md5sum line itself
+sed '/^# *md5sum=/d' "$f" > "$f.md5"
+
+# Update the md5sum line with the correct hash
+sed -i "s/^# *md5sum=.*/# md5sum=\"$(md5sum "$f.md5" | sed 's/ .*//')\"/" "$f"
+
+# Clean up temporary files
+rm -f "$f.md5"

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/poap.cfg
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/poap.cfg
@@ -1,0 +1,47 @@
+hostname switch
+vdc switch id 1
+  limit-resource vlan minimum 16 maximum 4094
+  limit-resource vrf minimum 2 maximum 4096
+  limit-resource port-channel minimum 0 maximum 511
+  limit-resource m4route-mem minimum 58 maximum 58
+  limit-resource m6route-mem minimum 8 maximum 8
+
+feature netconf
+feature openconfig
+feature lacp
+! feature lldp
+
+no password strength-check
+username admin password 5 $5$LFGHKE$ND3U7npkwgMUzxLjjgDQxCx8JFJ5.ZlFyQTTt1vZgA5  role network-admin
+ssh key rsa 2048 force
+
+system default switchport
+
+vrf context management
+  ip name-server 192.168.32.254
+  ip route 0.0.0.0/0 192.168.32.1
+
+interface mgmt0
+  ip address dhcp
+  vrf member management
+
+interface Ethernet1/1
+  description "Trunk port"
+  switchport
+  switchport mode trunk
+  no shutdown
+
+interface Ethernet1/2
+  description "Access port ironic0"
+  switchport
+  switchport mode access
+  no shutdown
+
+interface Ethernet1/3
+  description "Access port ironic1"
+  switchport
+  switchport mode access
+  no shutdown
+
+line console
+line vty

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/poap.py
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/poap.py
@@ -1,0 +1,437 @@
+#!/bin/env python3
+# md5sum="9e17ba7c52a86b52319cf76678fdf9aa"
+
+# If any changes are made to this script, please run the below command
+# in bash shell to update the above md5sum. This is used for integrity check.
+# f=poap.py ; sed '/^# *md5sum/d' "$f" > "$f.md5" ; sed -i \
+# "s/^# *md5sum=.*/#md5sum=\"$(md5sum $f.md5 | sed 's/ .*//')\"/" $f
+
+# Protocol Authentication Support:
+# - SCP: Always requires username and password
+# - HTTP/HTTPS: Authentication optional (anonymous or username/password)
+# - TFTP: No authentication support (anonymous only)
+#
+# Authentication parameters (username/password) are only required for SCP.
+# For HTTP/HTTPS, if you provide username, you must also provide password.
+#
+# Example usage:
+# - Anonymous HTTP: protocol="http", hostname="server.com" (no auth needed)
+# - Authenticated HTTP: protocol="http", hostname="server.com", port=8080, username="user", password="pass"
+# - Anonymous TFTP: protocol="tftp", hostname="server.com" (no auth supported)
+# - Authenticated SCP: protocol="scp", hostname="server.com", username="user", password="pass" (auth required)
+
+import os
+import re
+import signal
+import sys
+import syslog
+import traceback
+import time
+
+try:
+    from cisco import cli
+except ImportError:
+    from cli import *
+
+# Default configuration options
+DEFAULT_OPTS = {
+    "hostname": "192.168.32.254",
+    "protocol": "tftp",
+    "cfg_path": "/poap.cfg",
+    "dest_path": "bootflash:poap.cfg",
+    "ignore_cert": True,
+    # username, password and port are optional - only needed for SCP or authenticated HTTP/HTTPS
+    # port is optional for custom ports on any protocol (e.g., SCP:2222, HTTP:8080, HTTPS:8088, TFTP:6969)
+}
+
+# Valid configuration options
+VALID_OPTS = {
+    "username",
+    "password",
+    "hostname",
+    "protocol",
+    "port",
+    "cfg_path",
+    "dest_path",
+    "ignore_cert",
+    "vrf",
+}
+
+# Required configuration parameters (always required)
+REQUIRED_OPTS = {"hostname"}
+
+# Logging prefix for syslog messages
+SYSLOG_PREFIX = "POAPHandler"
+
+
+def get_log_file_path():
+    """Generate the log file path with timestamp and PID"""
+    return "/bootflash/%s_poap_%s_script.log" % (
+        time.strftime("%Y%m%d%H%M%S", time.gmtime()),
+        os.environ["POAP_PID"],
+    )
+
+
+class POAPHandler:
+    """
+    POAP (Power-On Auto Provisioning) handler for Cisco NXOS switches.
+    Handles configuration download and application for switch bootstrap.
+    """
+
+    def __init__(self):
+        """Initialize the POAP handler with default settings."""
+
+        # Set up signal handler
+        signal.signal(signal.SIGTERM, self.sigterm_handler)
+
+        # Initialize logging
+        self.syslog_prefix = SYSLOG_PREFIX
+        self.log_file_handler = None  # Will be set when using context manager
+
+        self.opts = DEFAULT_OPTS.copy()
+
+        # Validate required parameters
+        self._validate_required_opts()
+
+        # Check that options are valid
+        self.validate_opts()
+
+    @property
+    def dest_path(self):
+        """Normalized destination path without trailing slashes"""
+        return self.opts["dest_path"].rstrip("/")
+
+    @property
+    def cfg_path(self):
+        """Normalized config path without trailing slashes"""
+        return self.opts["cfg_path"].rstrip("/")
+
+    def _validate_required_opts(self):
+        """Validates that required options are provided"""
+        missing_params = REQUIRED_OPTS.difference(self.opts.keys())
+
+        if missing_params:
+            self._log("Required parameters are missing:")
+            self.abort("Missing %s" % ", ".join(missing_params))
+
+        # Protocol-specific validation for authentication parameters
+        protocol = self.opts.get("protocol", "http")
+
+        # SCP always requires authentication
+        if protocol == "scp":
+            username = self.opts.get("username")
+            password = self.opts.get("password")
+            if not username or not password:
+                self.abort("SCP protocol requires both username and password")
+
+        # HTTP/HTTPS with authentication requires both username and password
+        if protocol in ["http", "https"]:
+            username = self.opts.get("username")
+            password = self.opts.get("password")
+            if (username and not password) or (password and not username):
+                self.abort(
+                    "HTTP/HTTPS authentication requires both username and password"
+                )
+
+        # Validate port if provided
+        port = self.opts.get("port")
+        if port is not None:
+            try:
+                port_int = int(port)
+                if not (1 <= port_int <= 65535):
+                    self.abort("Port must be between 1 and 65535")
+            except (ValueError, TypeError):
+                self.abort("Port must be a valid integer")
+
+    def validate_opts(self):
+        """
+        Validates that the options provided by the user are valid.
+        Aborts the script if they are not.
+        """
+        # Find any invalid options (ones not in VALID_OPTS)
+        invalid_opts = set(self.opts.keys()) - VALID_OPTS
+        if invalid_opts:
+            self._log(
+                "Invalid options detected: %s (check spelling, capitalization, and underscores)"
+                % ", ".join(invalid_opts)
+            )
+            self.abort()
+
+    def abort(self, msg=None):
+        """Aborts the POAP script
+
+        :param msg: The message to log before aborting
+        """
+        if msg:
+            self._log(msg)
+
+        # Destination config
+        self.cleanup_file_from_option("dest_cfg")
+
+        # Log file will be closed by context manager
+        exit(1)
+
+    def _redact_passwords(self, message):
+        """Redacts passwords from log messages for security
+
+        :param message: The log message to redact passwords from
+        :return: The message with passwords replaced with '<removed>'
+        """
+        parts = re.split("\s+", message.strip())
+        for index, part in enumerate(parts):
+            # blank out the password after the password keyword (terminal password *****, etc.)
+            if part == "password" and len(parts) >= index + 2:
+                parts[index + 1] = "<removed>"
+
+        return " ".join(parts)
+
+    def _log(self, info):
+        """
+        Log the trace into console and poap_script log file in bootflash
+
+        :param info: The information that needs to be logged.
+        """
+        # Redact sensitive information before logging
+        info = self._redact_passwords(info)
+
+        # Add syslog prefix
+        info = "%s - %s" % (self.syslog_prefix, info)
+
+        syslog.syslog(9, info)
+        if self.log_file_handler is not None:
+            print(info, file=self.log_file_handler, flush=True)
+
+    def remove_file(self, filename):
+        """Removes a file if it exists and it's not a directory.
+
+        :param filename: The file to remove
+        """
+        if os.path.isfile(filename):
+            try:
+                os.remove(filename)
+            except (IOError, OSError) as e:
+                self._log("Failed to remove %s: %s" % (filename, str(e)))
+
+    def cleanup_file_from_option(self, option, bootflash_root=False):
+        """Removes a file indicated by the option in the POAP opts and removes it if it exists.
+
+        Handle the cases where the variable is unused or not set yet.
+
+        :param option: The option to remove
+        :param bootflash_root: Whether to remove the file from the bootflash root
+        """
+        try:
+            filename = self.opts[option]
+            if filename is None:
+                return  # Nothing to clean up
+
+            if bootflash_root:
+                path = "/bootflash"
+            else:
+                path = self.dest_path
+
+            self.remove_file(os.path.join(path, filename))
+            self.remove_file(os.path.join(path, "%s.tmp" % filename))
+        except KeyError:
+            # Option doesn't exist, nothing to clean up
+            pass
+
+    def sigterm_handler(self, signum, stack):
+        """
+        A signal handler for the SIGTERM signal. Cleans up and exits
+
+        :param signum: The signal number
+        :param stack: The stack trace
+        """
+        self.abort("SIGTERM signal received")
+
+    def process_cfg_file(self):
+        """
+        Processes the downloaded switch configuration file.
+        Copies the config to the scheduled config file for bootstrap replay.
+        """
+        self._log("Processing Config file")
+
+        # Copy config directly to scheduled-config
+        self._log("Command: copy %s scheduled-config" % self.opts["dest_path"])
+        cli("copy %s scheduled-config" % self.opts["dest_path"])
+
+        self._log("Config processed and prepared for scheduled application")
+
+    def _build_copy_cmd(self, source, dest):
+        """Build the copy command with all necessary options
+
+        :param source: Source file path on remote server
+        :param dest: Destination path on local switch
+        :return: Complete copy command string
+        """
+        # Extract parameters from opts
+        protocol = self.opts["protocol"]
+        host = self.opts["hostname"]
+        user = self.opts.get("username")
+        password = self.opts.get("password")
+        vrf = self.opts["vrf"]
+        ignore_ssl = self.opts["ignore_cert"]
+        port = self.opts.get("port")
+        # Build copy command with Cisco NX-OS terminal automation features
+        parts = []
+
+        # terminal dont-ask: Auto-answer "yes" to all confirmation prompts
+        parts.append("terminal dont-ask")
+
+        # Determine if authentication is needed based on protocol and credentials
+        auth_needed = protocol in ["scp"] or (
+            protocol in ["http", "https"] and user and password
+        )
+
+        if auth_needed:
+            if password:
+                # terminal password: Pre-store password for automatic authentication
+                # The password will be used automatically for any auth prompts during copy
+                parts.append("terminal password %s" % password)
+
+        # Build the copy URL - only include user@ if authentication is needed
+        url = "%s://" % protocol
+        if auth_needed and user:
+            url += "%s@" % user
+
+        # Add hostname with optional port
+        url += host
+        if port:
+            url += ":%s" % port
+
+        # Ensure source path starts with / for proper URL construction
+        if not source.startswith("/"):
+            source = "/" + source
+        url += source
+
+        # Build the copy command with URL and destination
+        cmd = "copy %s %s" % (url, dest)
+
+        # Add ignore-certificate if needed
+        if protocol == "https" and ignore_ssl:
+            cmd += " ignore-certificate"
+
+        # Add VRF
+        cmd += " vrf %s" % vrf
+
+        # Add the complete copy command to the parts
+        parts.append(cmd)
+
+        # Join all command parts with semicolon separator
+        return " ; ".join(parts)
+
+    def copy(self, source, dest):
+        """Copies the files
+
+        Copy the provided file from source to destination via network transfer.
+
+        :param source: The source file to copy
+        :param dest: The destination file to copy
+        """
+        self._log("Copying %s to %s" % (source, dest))
+
+        # Build the copy command using the dedicated method
+        cmd = self._build_copy_cmd(source, dest)
+        self._log("Copy command: %s" % cmd)
+
+        try:
+            cli(cmd)
+        except Exception as e:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            traceback_str = "".join(
+                traceback.format_exception(exc_type, exc_value, exc_tb)
+            )
+            self._log("Copy failed, Traceback: %s" % traceback_str)
+            self.abort("Copy failed: %s" % str(e))
+
+        self._log("Copy completed successfully")
+
+    def get_currently_booted_image_filename(self):
+        match = None
+        try:
+            output = cli("show version")
+        except Exception as e:
+            self.abort("Show version failed: %s" % str(e))
+
+        match = re.search("NXOS image file is:\s+(.+)", output)
+
+        if match:
+            directory, image = os.path.split(match.group(1))
+            return image.strip()
+
+    def install_nxos(self):
+        """Install the NXOS image on the switch
+
+        Assume the current image is the one we want to install.
+        """
+        boot_image = self.get_currently_booted_image_filename()
+        if not boot_image:
+            self.abort("No image found to install")
+
+        # Build the install command
+        parts = []
+        parts.append("terminal dont-ask ")
+        parts.append("install all nxos %s no-reload non-interruptive" % boot_image)
+        parts.append("terminal dont-ask")
+        parts.append("write erase")
+        cmd = " ; ".join(parts)
+        self._log("Install command: %s" % cmd)
+
+        try:
+            cli(cmd)
+            time.sleep(5)
+        except Exception as e:
+            self._log("Failed to ISSU to image %s" % boot_image)
+            self.abort(str(e))
+
+    def run_with_logging(self):
+        """Execute the POAP provisioning process with proper log file management"""
+        log_file = get_log_file_path()
+
+        with open(log_file, "w+") as log_file_handler:
+            self.log_file_handler = log_file_handler
+            self._log("Logfile name: %s" % log_file)
+
+            try:
+                self.run()
+            finally:
+                # Ensure log_file_handler is reset when context exits
+                self.log_file_handler = None
+
+    def run(self):
+        """Execute the POAP provisioning process"""
+
+        # Set dynamic VRF value from environment
+        self.opts.setdefault("vrf", os.environ.get("POAP_VRF", "management"))
+
+        # # create the directory structure needed, if any
+        # self.create_dest_dirs()
+
+        # Copy config
+        self.copy(self.opts["cfg_path"], self.opts["dest_path"])
+        self.process_cfg_file()
+
+        # Install the NXOS image
+        self.install_nxos()
+
+
+def main():
+    """Main entry point for the POAP script"""
+    poap_handler = POAPHandler()
+    poap_handler.run_with_logging()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        # Create a temporary handler just for error logging
+        handler = POAPHandler()
+
+        # Log the full traceback as a single formatted string
+        traceback_str = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+        handler._log("Exception occurred:\n%s" % traceback_str)
+
+        handler.abort()


### PR DESCRIPTION
- Add hotstack-nxos DIB element:
  - Builds a CentOS 9 switch-host image with NXOS qcow2 and GNS3 OVMF firmware baked in. NXOS runs as a nested KVM VM with macvtap passthrough for direct L2 access to OpenStack ports.

- Add devstack-nxos-vlan-netconf scenario
  - Cisco NX-OS 9000v scenario using nested KVM with macvtap passthrough and POAP bootstrap. Uses netconf_openconfig driver for NGS switch management.

Assisted-By: Claude (claude-4.5-sonnet)