### PR TITLE
Make wait_for_hosts optional

### DIFF
--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -22,6 +22,8 @@ nfs_exports:
   - path: "{{ sushy_emulator_state_nfs_path }}"
     mode: '0777'  # World writable for container access
 
+wait_for_hosts: []
+
 controller_install_openstack_client: false
 
 # Hotstack git server for GitOps deployments


### PR DESCRIPTION
The wait_for_hosts was added to enable waiting for network switch instances that are slow to boot, to be ready - but it was not made optional - scenarios not using wait_for_hosts failed with 'wait_for_hosts' is undefined.