### PR TITLE
Add HotPxeChain UEFI PXE chainloader application

### DIFF
--- a/images/.gitignore
+++ b/images/.gitignore
@@ -7,3 +7,5 @@ switch-host-base.qcow2
 .ci-framework/
 .nat64-build/
 .controller-build/
+uefi-netboot.img
+hot-pxe-chain/*.efi

--- a/images/Makefile
+++ b/images/Makefile
@@ -11,6 +11,11 @@ MICROSHIFT_RPM_ARCHIVE       ?=
 BLANK_IMAGE_NAME             ?= blank-image.qcow2
 BLANK_IMAGE_FORMAT           ?= raw
 BLANK_IMAGE_SIZE             ?= 1M
+UEFI_NETBOOT_IMAGE_NAME      ?= uefi-netboot.img
+UEFI_NETBOOT_IMAGE_SIZE      ?= 10M
+UEFI_NETBOOT_ESP_SIZE        ?= 8M
+HOT_PXE_CHAIN_DIR           ?= $(CURDIR)/hot-pxe-chain
+HOT_PXE_CHAIN_CONTAINER_IMAGE ?= localhost/hot-pxe-chain-build:latest
 NAT64_IMAGE_NAME             ?= nat64-appliance.qcow2
 NAT64_IMAGE_FORMAT           ?= raw
 NAT64_CIFMW_DIR              ?= $(CURDIR)/.ci-framework
@@ -45,7 +50,7 @@ SONIC_IMAGE                 ?=
 
 all: controller microshift blank nat64
 
-clean: controller_clean microshift_clean blank_clean nat64_clean
+clean: controller_clean microshift_clean blank_clean nat64_clean uefi-netboot_clean
 
 controller: controller_dib_setup controller_dib_build controller_convert
 
@@ -142,6 +147,38 @@ blank:
 
 blank_clean:
 	rm -f $(BLANK_IMAGE_NAME)
+
+uefi-netboot: uefi-netboot_build_efi uefi-netboot_disk
+
+uefi-netboot_build_efi:
+	@echo "Building HotPxeChain.efi in container..."
+	podman build -t $(HOT_PXE_CHAIN_CONTAINER_IMAGE) $(HOT_PXE_CHAIN_DIR)
+	@echo "Extracting HotPxeChain.efi from container..."
+	podman create --name hot-pxe-chain-extract $(HOT_PXE_CHAIN_CONTAINER_IMAGE) /bin/true
+	podman cp hot-pxe-chain-extract:/edk2/Build/HotPxeChainPkg/RELEASE_GCC/X64/HotPxeChain.efi \
+		$(HOT_PXE_CHAIN_DIR)/HotPxeChain.efi
+	podman rm hot-pxe-chain-extract
+	@echo "HotPxeChain.efi extracted to $(HOT_PXE_CHAIN_DIR)/HotPxeChain.efi"
+
+uefi-netboot_disk: uefi-netboot_build_efi
+	@echo "Creating GPT+ESP disk image..."
+	truncate -s $(UEFI_NETBOOT_IMAGE_SIZE) $(UEFI_NETBOOT_IMAGE_NAME)
+	sgdisk --clear \
+		--new=1:2048:+$(UEFI_NETBOOT_ESP_SIZE) \
+		--typecode=1:EF00 \
+		--change-name=1:ESP \
+		$(UEFI_NETBOOT_IMAGE_NAME)
+	mformat -i $(UEFI_NETBOOT_IMAGE_NAME)@@1M -v RESCUE ::
+	mmd -i $(UEFI_NETBOOT_IMAGE_NAME)@@1M ::EFI
+	mmd -i $(UEFI_NETBOOT_IMAGE_NAME)@@1M ::EFI/BOOT
+	mcopy -i $(UEFI_NETBOOT_IMAGE_NAME)@@1M \
+		$(HOT_PXE_CHAIN_DIR)/HotPxeChain.efi ::EFI/BOOT/BOOTX64.EFI
+	@echo "UEFI netboot image ready: $(UEFI_NETBOOT_IMAGE_NAME)"
+
+uefi-netboot_clean:
+	rm -f $(UEFI_NETBOOT_IMAGE_NAME)
+	rm -f $(HOT_PXE_CHAIN_DIR)/HotPxeChain.efi
+	-podman rmi $(HOT_PXE_CHAIN_CONTAINER_IMAGE) 2>/dev/null
 
 nat64: nat64_setup nat64_build nat64_convert
 

--- a/images/README.md
+++ b/images/README.md
@@ -31,6 +31,18 @@ deployments. The tasks are executed using the `make` utility.
   nested KVM virtual machine with macvtap passthrough networking. Uses GNS3's
   custom OVMF firmware for UEFI boot. Built using diskimage-builder (DIB) with
   the `hotstack-nxos` element
+- **uefi-netboot**: A minimal 10MB raw disk image with a GPT partition table
+  and an EFI System Partition containing `HotPxeChain.efi` as the default
+  bootloader (`/EFI/BOOT/BOOTX64.EFI`). HotPxeChain is a custom UEFI
+  application (built from `hot-pxe-chain/` using the edk2 SDK) that drives the
+  firmware's native PXE boot stack: it connects all controllers, locates PXE
+  Base Code protocol handles, performs DHCP (IPv4 first, IPv6 fallback), then
+  TFTP-downloads and chainloads the network boot program (e.g. `snponly.efi`).
+  This produces clean UEFI PXE client identifiers (`PXEClient:Arch:00007`)
+  without iPXE fingerprints, allowing the DHCP server to distinguish the two
+  boot stages. Intended for use as an OpenStack Nova rescue image to test the
+  full PXE chain (HotPxeChain → DHCP → NBP download → iPXE script →
+  kernel/ramdisk)
 
 ## Download Pre-built Images
 
@@ -82,6 +94,15 @@ The following sections describe how to build images locally using the included M
 - `BLANK_IMAGE_FORMAT`: The format for the blank image (default: `raw`). Can be
   set to `qcow2` or any format supported by `qemu-img`.
 - `BLANK_IMAGE_SIZE`: The size of the blank image file in megabytes.
+- `UEFI_NETBOOT_IMAGE_NAME`: The name of the UEFI netboot image file
+  (default: `uefi-netboot.img`).
+- `UEFI_NETBOOT_IMAGE_SIZE`: Total size of the disk image (default: `10M`).
+- `UEFI_NETBOOT_ESP_SIZE`: Size of the EFI System Partition (default: `8M`).
+- `HOT_PXE_CHAIN_DIR`: Path to the `hot-pxe-chain/` source directory containing
+  the UEFI application source and Containerfile (default: `./hot-pxe-chain`).
+- `HOT_PXE_CHAIN_CONTAINER_IMAGE`: Container image tag used for the edk2 build
+  environment (default: `localhost/hot-pxe-chain-build:latest`). Cached after
+  first build.
 - `NAT64_IMAGE_NAME`: The name of the NAT64 appliance image file.
 - `NAT64_IMAGE_FORMAT`: The desired format for the NAT64 image (default: `raw`).
   Set to `qcow2` to keep the original format.
@@ -155,6 +176,16 @@ directly use qcow2 images for VM disks.
 - `blank`: A target that creates a blank image file of the specified size in the
   format specified by `BLANK_IMAGE_FORMAT`.
 - `blank_clean`: A target that removes the blank image file.
+- `uefi-netboot`: Builds `HotPxeChain.efi` in a container (edk2 SDK), then
+  creates a minimal raw disk image with a GPT partition table and an EFI System
+  Partition containing the compiled EFI application as `/EFI/BOOT/BOOTX64.EFI`.
+  Requires `podman`, `sgdisk`, and `mtools`.
+  - `uefi-netboot_build_efi`: Builds the edk2 container image and extracts
+    `HotPxeChain.efi` from it.
+  - `uefi-netboot_disk`: Creates the GPT+ESP disk image and copies
+    `HotPxeChain.efi` onto the ESP.
+- `uefi-netboot_clean`: Removes the uefi-netboot image, extracted EFI
+  binary, and the build container image.
 - `nat64`: A target that depends on `nat64_setup`, `nat64_build`, and
   `nat64_convert`.
   - `nat64_setup`: A target that clones ci-framework and sets up the molecule
@@ -304,6 +335,53 @@ make clean
      --property hw_firmware_type=uefi \
      --property hw_machine_type=q35 \
      --property os_shutdown_timeout=5
+   ```
+
+#### Building and uploading the uefi-netboot image to glance
+
+1. Create the uefi-netboot image:
+
+   ```shell
+   make uefi-netboot
+   ```
+
+   This will:
+   - Build a container image with the edk2 SDK and compile `HotPxeChain.efi`
+     (cached after first run via `podman build`)
+   - Extract the compiled EFI application from the container
+   - Create a 10MB GPT+ESP disk image
+   - Copy `HotPxeChain.efi` as `/EFI/BOOT/BOOTX64.EFI` onto the ESP
+
+2. Upload the uefi-netboot image to Glance:
+
+   ```shell
+   openstack image create uefi-netboot \
+     --disk-format raw \
+     --file uefi-netboot.img \
+     --tag hotstack \
+     --property hw_firmware_type=uefi \
+     --property hw_machine_type=q35 \
+     --property hw_rescue_device=disk
+   ```
+
+   **Note**: The `hw_firmware_type=uefi` and `hw_machine_type=q35` properties
+   are required so that OVMF firmware is used when booting the rescue image.
+
+3. Rescue an instance and watch the console log:
+
+   ```shell
+   openstack server rescue --image uefi-netboot <instance-id>
+   openstack console log show <instance-id>
+   ```
+
+   In the console log, look for `HotPxeChain:` status messages showing
+   controller connection, PXE handle discovery, DHCP progress, and NBP
+   chainloading. The boot sequence is:
+
+   ```
+   HotPxeChain.efi (DHCP with PXEClient:Arch:00007)
+     → snponly.efi (DHCP with iPXE user-class)
+       → iPXE script → kernel + ramdisk
    ```
 
 #### Building and uploading the NAT64 appliance image to glance

--- a/images/hot-pxe-chain/Containerfile
+++ b/images/hot-pxe-chain/Containerfile
@@ -1,0 +1,17 @@
+FROM quay.io/centos/centos:stream10
+
+RUN dnf install -y epel-release \
+    && /usr/bin/crb enable \
+    && dnf install -y \
+        gcc gcc-c++ nasm python3 make libuuid-devel git \
+    && dnf clean all
+
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
+        https://github.com/tianocore/edk2.git /edk2
+
+WORKDIR /edk2
+RUN make -C BaseTools
+
+COPY HotPxeChainPkg/ HotPxeChainPkg/
+RUN bash -c 'source edksetup.sh && \
+    build -a X64 -t GCC -b RELEASE -p HotPxeChainPkg/HotPxeChainPkg.dsc'

--- a/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChain.c
+++ b/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChain.c
@@ -1,0 +1,770 @@
+/** @file
+  HotPxeChain - UEFI PXE chainloader.
+
+  Drives the firmware's native PXE boot stack to DHCP and TFTP-download the
+  network boot program (e.g. snponly.efi), then chainloads it.
+
+  SPDX-License-Identifier: Apache-2.0
+
+  NOTE: The compiled binary statically links edk2 libraries covered by
+  BSD-2-Clause-Patent; see LICENSE-edk2 for details.
+**/
+
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/PrintLib.h>
+#include <Protocol/PxeBaseCode.h>
+
+#define DHCPV4_OPT_SERVER_ID     54
+#define DHCPV4_OPT_TFTP_SERVER   66
+#define DHCPV4_OPT_BOOTFILE      67
+
+#define DHCPV6_OPT_BOOTFILE_URL  59
+
+/**
+  Connect every controller recursively so network-stack DXE drivers
+  (SNP, MNP, IP4/IP6, UDP4/UDP6, MTFTP4/6, PXE BC) are started
+  before we look for PXE Base Code handles.
+**/
+STATIC
+VOID
+ConnectAllControllers (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       HandleCount;
+  EFI_HANDLE  *HandleBuffer;
+
+  Status = gBS->LocateHandleBuffer (
+                  AllHandles, NULL, NULL, &HandleCount, &HandleBuffer
+                  );
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  for (UINTN Index = 0; Index < HandleCount; Index++) {
+    gBS->ConnectController (HandleBuffer[Index], NULL, NULL, TRUE);
+  }
+
+  FreePool (HandleBuffer);
+}
+
+/*
+ * ----------------------------------------------------------------
+ *  DHCPv4 option helpers
+ * ----------------------------------------------------------------
+ */
+
+/**
+  Find a DHCPv4 option in a raw DHCP packet.
+
+  DHCP options are TLV (code, length, value) starting at byte 240
+  (236-byte BOOTP header + 4-byte magic cookie).  Padding (0x00)
+  and end (0xFF) markers are handled per RFC 2132.
+
+  @param[in]  Pkt       Raw packet bytes.
+  @param[in]  PktLen    Total packet length.
+  @param[in]  OptCode   Option code to find (e.g. 67, 66, 54).
+  @param[out] OptLen    Length of the returned option data.
+
+  @return Pointer to option data, or NULL if not found.
+**/
+STATIC
+UINT8 *
+FindDhcpv4Option (
+  IN  UINT8   *Pkt,
+  IN  UINTN   PktLen,
+  IN  UINT8   OptCode,
+  OUT UINT8   *OptLen
+  )
+{
+  UINTN  Offset = 240;
+
+  while (Offset < PktLen) {
+    UINT8  Code = Pkt[Offset++];
+
+    if (Code == 0xFF) {
+      break;
+    }
+    if (Code == 0x00) {
+      continue;
+    }
+    if (Offset >= PktLen) {
+      break;
+    }
+
+    UINT8  Len = Pkt[Offset++];
+
+    if (Offset + Len > PktLen) {
+      break;
+    }
+    if (Code == OptCode) {
+      *OptLen = Len;
+      return &Pkt[Offset];
+    }
+
+    Offset += Len;
+  }
+
+  return NULL;
+}
+
+/**
+  Parse a dotted-quad ASCII string into an EFI_IPv4_ADDRESS.
+
+  @param[in]  Str   NUL-terminated ASCII string (e.g. "172.20.1.10").
+  @param[out] Addr  Parsed address.
+
+  @retval TRUE   Parsed successfully.
+  @retval FALSE  Not a valid dotted-quad.
+**/
+STATIC
+BOOLEAN
+ParseIpv4String (
+  IN  CHAR8            *Str,
+  OUT EFI_IPv4_ADDRESS *Addr
+  )
+{
+  UINTN  Octets[4];
+  UINTN  Count = 0;
+  CHAR8  *p    = Str;
+
+  while (Count < 4 && *p != '\0') {
+    UINTN Val = 0;
+    if (*p < '0' || *p > '9') {
+      return FALSE;
+    }
+    while (*p >= '0' && *p <= '9') {
+      Val = Val * 10 + (*p - '0');
+      p++;
+    }
+    if (Val > 255) {
+      return FALSE;
+    }
+    Octets[Count++] = Val;
+    if (*p == '.') {
+      p++;
+    }
+  }
+
+  if (Count != 4) {
+    return FALSE;
+  }
+
+  Addr->Addr[0] = (UINT8)Octets[0];
+  Addr->Addr[1] = (UINT8)Octets[1];
+  Addr->Addr[2] = (UINT8)Octets[2];
+  Addr->Addr[3] = (UINT8)Octets[3];
+  return TRUE;
+}
+
+/**
+  Extract boot filename and TFTP server IP from a DHCPv4 ACK.
+
+  Checks DHCP option 67 first, then the legacy BOOTP file field.
+  For the server IP: option 54, then option 66, then BOOTP siaddr.
+
+  @param[in]  Mode          PXE Base Code mode data.
+  @param[out] BootFileBuf   Buffer to receive NUL-terminated filename.
+  @param[in]  BufSize       Size of BootFileBuf.
+  @param[out] ServerIp      TFTP server address.
+
+  @retval EFI_SUCCESS       Both filename and server IP obtained.
+  @retval EFI_NOT_FOUND     Missing filename or server IP.
+**/
+STATIC
+EFI_STATUS
+GetBootInfoV4 (
+  IN  EFI_PXE_BASE_CODE_MODE  *Mode,
+  OUT CHAR8                    *BootFileBuf,
+  IN  UINTN                   BufSize,
+  OUT EFI_IP_ADDRESS           *ServerIp
+  )
+{
+  UINT8    *OptData;
+  UINT8    OptLen;
+  BOOLEAN  Found;
+
+  Found = FALSE;
+
+  OptData = FindDhcpv4Option (
+              Mode->DhcpAck.Raw, sizeof (Mode->DhcpAck.Raw),
+              DHCPV4_OPT_BOOTFILE, &OptLen
+              );
+  if (OptData != NULL && OptLen > 0 && OptLen < BufSize) {
+    CopyMem (BootFileBuf, OptData, OptLen);
+    BootFileBuf[OptLen] = '\0';
+    Found = TRUE;
+    Print (L"HotPxeChain: Boot file from DHCPv4 option 67\n");
+  }
+
+  if (!Found) {
+    CHAR8  *Legacy = (CHAR8 *)Mode->DhcpAck.Dhcpv4.BootpBootFile;
+    if (Legacy[0] != '\0') {
+      UINTN  Len = AsciiStrnLenS (Legacy, 128);
+      if (Len < BufSize) {
+        CopyMem (BootFileBuf, Legacy, Len);
+        BootFileBuf[Len] = '\0';
+        Found = TRUE;
+        Print (L"HotPxeChain: Boot file from BOOTP header\n");
+      }
+    }
+  }
+
+  if (!Found) {
+    Print (L"HotPxeChain: No boot filename in DHCPv4 response\n");
+    return EFI_NOT_FOUND;
+  }
+
+  ZeroMem (ServerIp, sizeof (*ServerIp));
+
+  OptData = FindDhcpv4Option (
+              Mode->DhcpAck.Raw, sizeof (Mode->DhcpAck.Raw),
+              DHCPV4_OPT_SERVER_ID, &OptLen
+              );
+  if (OptData != NULL && OptLen == 4) {
+    CopyMem (&ServerIp->v4, OptData, 4);
+    Print (L"HotPxeChain: Server IP from DHCPv4 option 54\n");
+  } else {
+    OptData = FindDhcpv4Option (
+                Mode->DhcpAck.Raw, sizeof (Mode->DhcpAck.Raw),
+                DHCPV4_OPT_TFTP_SERVER, &OptLen
+                );
+    if (OptData != NULL && OptLen > 0 && OptLen < 64) {
+      CHAR8  AddrStr[64];
+      CopyMem (AddrStr, OptData, OptLen);
+      AddrStr[OptLen] = '\0';
+      if (ParseIpv4String (AddrStr, &ServerIp->v4)) {
+        Print (L"HotPxeChain: Server IP from DHCPv4 option 66\n");
+      }
+    }
+  }
+
+  if (ServerIp->v4.Addr[0] == 0 && ServerIp->v4.Addr[1] == 0 &&
+      ServerIp->v4.Addr[2] == 0 && ServerIp->v4.Addr[3] == 0) {
+    CopyMem (
+      &ServerIp->v4,
+      Mode->DhcpAck.Dhcpv4.BootpSiAddr,
+      sizeof (EFI_IPv4_ADDRESS)
+      );
+    if (ServerIp->v4.Addr[0] != 0 || ServerIp->v4.Addr[1] != 0 ||
+        ServerIp->v4.Addr[2] != 0 || ServerIp->v4.Addr[3] != 0) {
+      Print (L"HotPxeChain: Server IP from BOOTP siaddr\n");
+    }
+  }
+
+  if (ServerIp->v4.Addr[0] == 0 && ServerIp->v4.Addr[1] == 0 &&
+      ServerIp->v4.Addr[2] == 0 && ServerIp->v4.Addr[3] == 0) {
+    Print (L"HotPxeChain: No TFTP server IP in DHCPv4 response\n");
+    return EFI_NOT_FOUND;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/*
+ * ----------------------------------------------------------------
+ *  DHCPv6 option helpers
+ * ----------------------------------------------------------------
+ */
+
+/**
+  Find a DHCPv6 option in a raw DHCPv6 packet.
+
+  DHCPv6 options are TLV with 2-byte code and 2-byte length
+  (both big-endian), starting at byte 4 of the packet (after the
+  1-byte message type + 3-byte transaction ID).  Per RFC 8415.
+
+  @param[in]  Pkt       Raw packet bytes.
+  @param[in]  PktLen    Total packet length.
+  @param[in]  OptCode   16-bit option code to find (e.g. 59).
+  @param[out] OptLen    Length of the returned option data.
+
+  @return Pointer to option data, or NULL if not found.
+**/
+STATIC
+UINT8 *
+FindDhcpv6Option (
+  IN  UINT8    *Pkt,
+  IN  UINTN    PktLen,
+  IN  UINT16   OptCode,
+  OUT UINT16   *OptLen
+  )
+{
+  UINTN  Offset = 4;
+
+  while (Offset + 4 <= PktLen) {
+    UINT16  Code = (UINT16)((Pkt[Offset] << 8) | Pkt[Offset + 1]);
+    UINT16  Len  = (UINT16)((Pkt[Offset + 2] << 8) | Pkt[Offset + 3]);
+
+    Offset += 4;
+
+    if (Offset + Len > PktLen) {
+      break;
+    }
+    if (Code == OptCode) {
+      *OptLen = Len;
+      return &Pkt[Offset];
+    }
+
+    Offset += Len;
+  }
+
+  return NULL;
+}
+
+/**
+  Parse an IPv6 address string into an EFI_IPv6_ADDRESS.
+
+  Handles full and :: compressed forms per RFC 5952.
+
+  @param[in]  Str     ASCII string (not necessarily NUL-terminated).
+  @param[in]  StrLen  Number of characters to parse.
+  @param[out] Addr    Parsed address.
+
+  @retval TRUE   Parsed successfully.
+  @retval FALSE  Not a valid IPv6 address.
+**/
+STATIC
+BOOLEAN
+ParseIpv6String (
+  IN  CHAR8            *Str,
+  IN  UINTN            StrLen,
+  OUT EFI_IPv6_ADDRESS *Addr
+  )
+{
+  UINT16   Groups[8];
+  UINTN    GroupCount    = 0;
+  UINTN    DblColonPos  = 8;
+  BOOLEAN  SeenDblColon = FALSE;
+  CHAR8    *p            = Str;
+  CHAR8    *End          = Str + StrLen;
+
+  ZeroMem (Groups, sizeof (Groups));
+
+  while (p < End && GroupCount < 8) {
+    if (p + 1 < End && p[0] == ':' && p[1] == ':') {
+      if (SeenDblColon) {
+        return FALSE;
+      }
+      SeenDblColon = TRUE;
+      DblColonPos  = GroupCount;
+      p += 2;
+      continue;
+    }
+
+    if (*p == ':') {
+      p++;
+      continue;
+    }
+
+    UINT16   Val       = 0;
+    BOOLEAN  HasDigits = FALSE;
+    while (p < End && *p != ':') {
+      UINT8  Nibble;
+      if (*p >= '0' && *p <= '9') {
+        Nibble = (UINT8)(*p - '0');
+      } else if (*p >= 'a' && *p <= 'f') {
+        Nibble = (UINT8)(*p - 'a' + 10);
+      } else if (*p >= 'A' && *p <= 'F') {
+        Nibble = (UINT8)(*p - 'A' + 10);
+      } else {
+        return FALSE;
+      }
+      Val = (UINT16)((Val << 4) | Nibble);
+      HasDigits = TRUE;
+      p++;
+    }
+
+    if (HasDigits) {
+      Groups[GroupCount++] = Val;
+    }
+  }
+
+  if (SeenDblColon) {
+    UINTN  TailLen = GroupCount - DblColonPos;
+    UINTN  Shift   = 8 - GroupCount;
+
+    for (UINTN i = TailLen; i > 0; i--) {
+      Groups[DblColonPos + Shift + i - 1] = Groups[DblColonPos + i - 1];
+    }
+    for (UINTN i = 0; i < Shift; i++) {
+      Groups[DblColonPos + i] = 0;
+    }
+  } else if (GroupCount != 8) {
+    return FALSE;
+  }
+
+  for (UINTN i = 0; i < 8; i++) {
+    Addr->Addr[i * 2]     = (UINT8)(Groups[i] >> 8);
+    Addr->Addr[i * 2 + 1] = (UINT8)(Groups[i] & 0xFF);
+  }
+
+  return TRUE;
+}
+
+/**
+  Extract boot filename and TFTP server IP from a DHCPv6 ACK.
+
+  Parses DHCPv6 option 59 (OPT_BOOTFILE_URL) which contains a URL
+  of the form  tftp://[IPv6-addr]/filename  (RFC 5970).
+
+  @param[in]  Mode          PXE Base Code mode data.
+  @param[out] BootFileBuf   Buffer to receive NUL-terminated filename.
+  @param[in]  BufSize       Size of BootFileBuf.
+  @param[out] ServerIp      TFTP server address.
+
+  @retval EFI_SUCCESS       Both filename and server IP obtained.
+  @retval EFI_NOT_FOUND     Option 59 missing or unparsable.
+**/
+STATIC
+EFI_STATUS
+GetBootInfoV6 (
+  IN  EFI_PXE_BASE_CODE_MODE  *Mode,
+  OUT CHAR8                    *BootFileBuf,
+  IN  UINTN                   BufSize,
+  OUT EFI_IP_ADDRESS           *ServerIp
+  )
+{
+  UINT8   *OptData;
+  UINT16  OptLen;
+
+  OptData = FindDhcpv6Option (
+              Mode->DhcpAck.Raw, sizeof (Mode->DhcpAck.Raw),
+              DHCPV6_OPT_BOOTFILE_URL, &OptLen
+              );
+  if (OptData == NULL || OptLen == 0) {
+    Print (L"HotPxeChain: No boot file URL in DHCPv6 response (option 59)\n");
+    return EFI_NOT_FOUND;
+  }
+
+  CHAR8  Url[512];
+  UINTN  CopyLen = (OptLen < sizeof (Url) - 1) ? OptLen : sizeof (Url) - 1;
+  CopyMem (Url, OptData, CopyLen);
+  Url[CopyLen] = '\0';
+
+  Print (L"HotPxeChain: Boot file URL: %a\n", Url);
+
+  /* Expect "tftp://..." (case-insensitive on the scheme) */
+  CHAR8  *p = Url;
+  if (!((p[0] == 't' || p[0] == 'T') &&
+        (p[1] == 'f' || p[1] == 'F') &&
+        (p[2] == 't' || p[2] == 'T') &&
+        (p[3] == 'p' || p[3] == 'P') &&
+        p[4] == ':' && p[5] == '/' && p[6] == '/')) {
+    Print (L"HotPxeChain: Unsupported URL scheme (expected tftp://)\n");
+    return EFI_NOT_FOUND;
+  }
+  p += 7;
+
+  ZeroMem (ServerIp, sizeof (*ServerIp));
+
+  if (*p == '[') {
+    /* IPv6 address in brackets: [addr] */
+    p++;
+    CHAR8  *AddrStart = p;
+    while (*p != '\0' && *p != ']') {
+      p++;
+    }
+    if (*p != ']') {
+      Print (L"HotPxeChain: Malformed bracketed IPv6 address\n");
+      return EFI_NOT_FOUND;
+    }
+    if (!ParseIpv6String (AddrStart, (UINTN)(p - AddrStart), &ServerIp->v6)) {
+      Print (L"HotPxeChain: Failed to parse IPv6 address\n");
+      return EFI_NOT_FOUND;
+    }
+    p++;
+    Print (L"HotPxeChain: Server IPv6 from boot file URL\n");
+  } else {
+    /* IPv4 address (less common in v6 context, but handle it) */
+    CHAR8  *AddrStart = p;
+    while (*p != '\0' && *p != '/' && *p != ':') {
+      p++;
+    }
+    CHAR8  Save = *p;
+    *p = '\0';
+    if (!ParseIpv4String (AddrStart, &ServerIp->v4)) {
+      Print (L"HotPxeChain: Failed to parse server address\n");
+      return EFI_NOT_FOUND;
+    }
+    *p = Save;
+    Print (L"HotPxeChain: Server IPv4 from boot file URL\n");
+  }
+
+  /* Skip optional :port */
+  if (*p == ':') {
+    while (*p != '\0' && *p != '/') {
+      p++;
+    }
+  }
+
+  /* Skip '/' separator */
+  if (*p == '/') {
+    p++;
+  }
+
+  if (*p == '\0') {
+    Print (L"HotPxeChain: No filename in boot file URL\n");
+    return EFI_NOT_FOUND;
+  }
+
+  UINTN  FileLen = AsciiStrLen (p);
+  if (FileLen >= BufSize) {
+    Print (L"HotPxeChain: Boot filename too long\n");
+    return EFI_NOT_FOUND;
+  }
+
+  CopyMem (BootFileBuf, p, FileLen);
+  BootFileBuf[FileLen] = '\0';
+
+  return EFI_SUCCESS;
+}
+
+/*
+ * ----------------------------------------------------------------
+ *  Common TFTP download + chainload
+ * ----------------------------------------------------------------
+ */
+
+/**
+  Download the NBP via TFTP and chainload it.
+
+  The NIC handle's device path is attached to the loaded image so
+  that SNP-based NBPs (e.g. snponly.efi) can locate their network
+  interface.
+
+  @param[in] PxeBc        PXE Base Code protocol instance.
+  @param[in] ImageHandle  This application's image handle.
+  @param[in] PxeHandle    Handle carrying the PXE BC (= NIC handle).
+  @param[in] ServerIp     TFTP server address.
+  @param[in] BootFile     NUL-terminated ASCII boot filename.
+
+  @retval EFI_SUCCESS   NBP started (may not return).
+  @retval other         TFTP or LoadImage/StartImage failure.
+**/
+STATIC
+EFI_STATUS
+TftpDownloadAndChainload (
+  IN EFI_PXE_BASE_CODE_PROTOCOL  *PxeBc,
+  IN EFI_HANDLE                  ImageHandle,
+  IN EFI_HANDLE                  PxeHandle,
+  IN EFI_IP_ADDRESS              *ServerIp,
+  IN CHAR8                       *BootFile
+  )
+{
+  EFI_STATUS                Status;
+  UINT64                    FileSize;
+  VOID                      *Buffer;
+  EFI_HANDLE                NbpHandle;
+  EFI_DEVICE_PATH_PROTOCOL  *NbpDevPath;
+  CHAR16                    UnicodeFile[512];
+  UINTN                     Idx;
+
+  FileSize = 0;
+  Status = PxeBc->Mtftp (
+                    PxeBc,
+                    EFI_PXE_BASE_CODE_TFTP_GET_FILE_SIZE,
+                    NULL, FALSE, &FileSize, NULL,
+                    ServerIp, (UINT8 *)BootFile, NULL, FALSE
+                    );
+  if (EFI_ERROR (Status)) {
+    Print (L"HotPxeChain: TFTP get-file-size failed: %r\n", Status);
+    return Status;
+  }
+
+  Print (L"HotPxeChain: Downloading %lu bytes ...\n", FileSize);
+
+  Buffer = AllocatePool ((UINTN)FileSize);
+  if (Buffer == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = PxeBc->Mtftp (
+                    PxeBc,
+                    EFI_PXE_BASE_CODE_TFTP_READ_FILE,
+                    Buffer, FALSE, &FileSize, NULL,
+                    ServerIp, (UINT8 *)BootFile, NULL, FALSE
+                    );
+  if (EFI_ERROR (Status)) {
+    Print (L"HotPxeChain: TFTP download failed: %r\n", Status);
+    FreePool (Buffer);
+    return Status;
+  }
+
+  /*
+   * Build a device path rooted at the NIC handle so that
+   * the loaded NBP can find its SNP binding.
+   */
+  for (Idx = 0; BootFile[Idx] != '\0' && Idx < sizeof (UnicodeFile) / sizeof (CHAR16) - 1; Idx++) {
+    UnicodeFile[Idx] = (CHAR16)(UINT8)BootFile[Idx];
+  }
+  UnicodeFile[Idx] = L'\0';
+
+  NbpDevPath = FileDevicePath (PxeHandle, UnicodeFile);
+
+  Print (L"HotPxeChain: Loading NBP image ...\n");
+
+  NbpHandle = NULL;
+  Status = gBS->LoadImage (
+                  FALSE, ImageHandle, NbpDevPath,
+                  Buffer, (UINTN)FileSize, &NbpHandle
+                  );
+  if (NbpDevPath != NULL) {
+    FreePool (NbpDevPath);
+  }
+  FreePool (Buffer);
+  if (EFI_ERROR (Status)) {
+    Print (L"HotPxeChain: LoadImage failed: %r\n", Status);
+    return Status;
+  }
+
+  Print (L"HotPxeChain: Starting NBP ...\n");
+
+  UINTN   ExitDataSize = 0;
+  CHAR16  *ExitData     = NULL;
+
+  Status = gBS->StartImage (NbpHandle, &ExitDataSize, &ExitData);
+  if (EFI_ERROR (Status)) {
+    Print (L"HotPxeChain: NBP returned: %r\n", Status);
+    if (ExitData != NULL) {
+      Print (L"HotPxeChain: NBP exit: %s\n", ExitData);
+      FreePool (ExitData);
+    }
+  }
+
+  return Status;
+}
+
+/**
+  Extract boot info from the DHCP ACK (v4 or v6) and chainload the NBP.
+**/
+STATIC
+EFI_STATUS
+DownloadAndChainload (
+  IN EFI_PXE_BASE_CODE_PROTOCOL  *PxeBc,
+  IN EFI_HANDLE                  ImageHandle,
+  IN EFI_HANDLE                  PxeHandle
+  )
+{
+  EFI_STATUS      Status;
+  CHAR8           BootFileBuf[512];
+  EFI_IP_ADDRESS  ServerIp;
+
+  if (PxeBc->Mode->UsingIpv6) {
+    Status = GetBootInfoV6 (PxeBc->Mode, BootFileBuf, sizeof (BootFileBuf), &ServerIp);
+  } else {
+    Status = GetBootInfoV4 (PxeBc->Mode, BootFileBuf, sizeof (BootFileBuf), &ServerIp);
+  }
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Print (L"HotPxeChain: NBP \"%a\"\n", BootFileBuf);
+
+  return TftpDownloadAndChainload (PxeBc, ImageHandle, PxeHandle, &ServerIp, BootFileBuf);
+}
+
+/*
+ * ----------------------------------------------------------------
+ *  Entry point
+ * ----------------------------------------------------------------
+ */
+
+EFI_STATUS
+EFIAPI
+UefiMain (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                   Status;
+  UINTN                        HandleCount;
+  EFI_HANDLE                   *HandleBuffer;
+  EFI_PXE_BASE_CODE_PROTOCOL   *PxeBc;
+
+  Print (L"HotPxeChain: Connecting controllers ...\n");
+  ConnectAllControllers ();
+
+  Status = gBS->LocateHandleBuffer (
+                  ByProtocol,
+                  &gEfiPxeBaseCodeProtocolGuid,
+                  NULL,
+                  &HandleCount,
+                  &HandleBuffer
+                  );
+  if (EFI_ERROR (Status) || HandleCount == 0) {
+    Print (L"HotPxeChain: No PXE Base Code handles found: %r\n", Status);
+    return EFI_NOT_FOUND;
+  }
+
+  Print (L"HotPxeChain: Found %u PXE handle(s)\n", HandleCount);
+
+  for (UINTN Index = 0; Index < HandleCount; Index++) {
+    Status = gBS->HandleProtocol (
+                    HandleBuffer[Index],
+                    &gEfiPxeBaseCodeProtocolGuid,
+                    (VOID **)&PxeBc
+                    );
+    if (EFI_ERROR (Status)) {
+      continue;
+    }
+
+    /* ---- IPv4 attempt ---- */
+    Print (L"HotPxeChain: Trying IPv4 on handle %u ...\n", Index);
+    Status = PxeBc->Start (PxeBc, FALSE);
+    if (EFI_ERROR (Status)) {
+      Print (L"HotPxeChain: IPv4 Start failed: %r\n", Status);
+      goto TryIpv6;
+    }
+
+    Status = PxeBc->Dhcp (PxeBc, TRUE);
+    if (EFI_ERROR (Status)) {
+      Print (L"HotPxeChain: IPv4 DHCP failed: %r\n", Status);
+      PxeBc->Stop (PxeBc);
+      goto TryIpv6;
+    }
+
+    Print (L"HotPxeChain: IPv4 DHCP succeeded\n");
+    Status = DownloadAndChainload (PxeBc, ImageHandle, HandleBuffer[Index]);
+    if (!EFI_ERROR (Status)) {
+      FreePool (HandleBuffer);
+      return EFI_SUCCESS;
+    }
+    PxeBc->Stop (PxeBc);
+
+TryIpv6:
+    /* ---- IPv6 fallback ---- */
+    Print (L"HotPxeChain: Trying IPv6 on handle %u ...\n", Index);
+    Status = PxeBc->Start (PxeBc, TRUE);
+    if (EFI_ERROR (Status)) {
+      Print (L"HotPxeChain: IPv6 Start failed: %r\n", Status);
+      continue;
+    }
+
+    Status = PxeBc->Dhcp (PxeBc, TRUE);
+    if (EFI_ERROR (Status)) {
+      Print (L"HotPxeChain: IPv6 DHCP failed: %r\n", Status);
+      PxeBc->Stop (PxeBc);
+      continue;
+    }
+
+    Print (L"HotPxeChain: IPv6 DHCP succeeded\n");
+    Status = DownloadAndChainload (PxeBc, ImageHandle, HandleBuffer[Index]);
+    if (!EFI_ERROR (Status)) {
+      FreePool (HandleBuffer);
+      return EFI_SUCCESS;
+    }
+    PxeBc->Stop (PxeBc);
+  }
+
+  FreePool (HandleBuffer);
+  Print (L"HotPxeChain: All PXE boot attempts failed\n");
+  return EFI_NOT_FOUND;
+}

--- a/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChain.inf
+++ b/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChain.inf
@@ -1,0 +1,38 @@
+## @file
+#  HotPxeChain - UEFI PXE chainloader.
+#
+#  Drives the firmware PXE stack (IPv4, IPv6 fallback) to DHCP for a
+#  network boot program and chainloads it via LoadImage + StartImage.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##
+
+[Defines]
+  INF_VERSION    = 1.25
+  BASE_NAME      = HotPxeChain
+  FILE_GUID      = 7B4E5F1A-D82C-4A93-B618-1F3E9D0C5A72
+  MODULE_TYPE    = UEFI_APPLICATION
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = UefiMain
+
+[Sources]
+  HotPxeChain.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  NetworkPkg/NetworkPkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  UefiLib
+  UefiBootServicesTableLib
+  BaseMemoryLib
+  MemoryAllocationLib
+  DevicePathLib
+  PrintLib
+  StackCheckLib
+
+[Protocols]
+  gEfiPxeBaseCodeProtocolGuid    ## CONSUMES
+  gEfiLoadFileProtocolGuid       ## SOMETIMES_CONSUMES

--- a/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChainPkg.dsc
+++ b/images/hot-pxe-chain/HotPxeChainPkg/HotPxeChainPkg.dsc
@@ -1,0 +1,55 @@
+## @file
+#  HotPxeChainPkg platform descriptor.
+#
+#  Maps each required LibraryClass to its MdePkg / MdeModulePkg
+#  implementation so the edk2 build system can resolve all
+#  transitive dependencies for HotPxeChain.efi.
+#
+#  SPDX-License-Identifier: Apache-2.0
+##
+
+[Defines]
+  PLATFORM_NAME           = HotPxeChainPkg
+  PLATFORM_GUID           = 3A29C6E8-F150-4B7D-A602-8E13F4B9D7C1
+  PLATFORM_VERSION        = 1.0
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/HotPxeChainPkg
+  SUPPORTED_ARCHITECTURES = X64
+  BUILD_TARGETS           = RELEASE|DEBUG
+
+[LibraryClasses]
+  #
+  # Entry point
+  #
+  UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
+
+  #
+  # UEFI / boot-services helpers
+  #
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+
+  #
+  # Memory & strings
+  #
+  BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+
+  #
+  # Stubs for transitive dependencies
+  #
+  DebugLib|MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+  StackCheckLib|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+
+[BuildOptions]
+  GCC:*_*_X64_CC_FLAGS = -march=x86-64 -fno-stack-protector
+  GCC:*_*_X64_DLINK_FLAGS = -march=x86-64
+
+[Components]
+  HotPxeChainPkg/HotPxeChain.inf

--- a/images/hot-pxe-chain/LICENSE-edk2
+++ b/images/hot-pxe-chain/LICENSE-edk2
@@ -1,0 +1,57 @@
+The compiled HotPxeChain.efi binary statically links library code from the
+TianoCore EDK II (edk2) project.  That library code is licensed under the
+following terms:
+
+=======================================================================
+
+Copyright (c) 2019, TianoCore and contributors.  All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+Subject to the terms and conditions of this license, each copyright holder
+and contributor hereby grants to those receiving rights under this license a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except for failure to satisfy the conditions of this license) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer this software, where such license applies only to those patent
+claims, already acquired or hereafter acquired, licensable by such copyright
+holder or contributor, that are necessarily infringed by:
+
+(a) their Contribution(s) (the licensed copyrights of copyright holders and
+    non-copyrightable additions of contributors, in source or binary form)
+    alone; or
+
+(b) combination of their Contribution(s) with the work of authorship to
+    which such Contribution(s) was added by such copyright holder or
+    contributor, if, at the time the Contribution is added, such addition
+    causes such combination to be necessarily infringed.  The patent license
+    shall not apply to any other combinations which include the
+    Contribution.
+
+Except as expressly stated above, no rights or licenses from any copyright
+holder or contributor is granted under this license, whether expressly, by
+implication, estoppel or otherwise.
+
+DISCLAIMER
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/images/hot-pxe-chain/README.md
+++ b/images/hot-pxe-chain/README.md
@@ -1,0 +1,40 @@
+# HotPxeChain
+
+A minimal UEFI application that drives the firmware's native PXE boot stack to
+DHCP and TFTP-download a network boot program (e.g. `snponly.efi`), then
+chainloads it.
+
+When placed as `/EFI/BOOT/BOOTX64.EFI` on the `uefi-netboot` disk image, OVMF
+loads it and it performs PXE DHCP with clean UEFI identifiers
+(`PXEClient:Arch:00007`, no iPXE fingerprint), allowing the DHCP server to
+distinguish the two boot stages and serve `snponly.efi` as the NBP.
+
+## Boot sequence
+
+```
+HotPxeChain.efi -> DHCP (PXEClient:Arch:00007) -> TFTP snponly.efi
+  -> iPXE DHCP (user-class: iPXE) -> boot script -> kernel + ramdisk
+```
+
+## Building
+
+Built automatically by `make uefi-netboot` in the parent `images/` directory.
+The Containerfile clones edk2, compiles `HotPxeChain.efi` inside a container,
+and the Makefile extracts it and places it on a GPT+ESP disk image.
+
+To build the EFI binary standalone:
+
+```shell
+podman build -t hot-pxe-chain-build .
+podman create --name extract hot-pxe-chain-build /bin/true
+podman cp extract:/edk2/Build/HotPxeChainPkg/RELEASE_GCC/X64/HotPxeChain.efi .
+podman rm extract
+```
+
+## Files
+
+- `HotPxeChainPkg/HotPxeChain.c` - Application source (Apache-2.0)
+- `HotPxeChainPkg/HotPxeChain.inf` - edk2 module descriptor
+- `HotPxeChainPkg/HotPxeChainPkg.dsc` - edk2 platform descriptor
+- `Containerfile` - Container build for compiling with edk2
+- `LICENSE-edk2` - BSD-2-Clause-Patent license for linked edk2 libraries

--- a/scenarios/sno-2-bm/README.md
+++ b/scenarios/sno-2-bm/README.md
@@ -150,7 +150,7 @@ Three boot interface modes are supported for the virtual Ironic nodes:
 
 - **`redfish-virtual-media`** (default): Virtual media boot via sushy-tools. Uses `heat_template.yaml`.
 - **`ipxe`**: Rescue-based iPXE network boot via sushy-tools Nova rescue mode. Uses `heat_template_ipxe.yaml`.
-- **`pxe`**: Traditional PXE boot with TFTP/shim (BIOS mode). Uses `heat_template_pxe.yaml`.
+- **`pxe`**: Native UEFI PXE boot via sushy-tools Nova rescue mode. Uses `heat_template_pxe.yaml`. The `uefi-netboot` Glance image contains `HotPxeChain.efi` (a custom UEFI application built from `images/hot-pxe-chain/`) as `/EFI/BOOT/BOOTX64.EFI`. OVMF loads HotPxeChain, which drives the firmware's native PXE stack with clean UEFI identifiers (`PXEClient:Arch:00007`, no iPXE fingerprint), allowing the DHCP server to serve `snponly.efi` as the NBP. Full chain: HotPxeChain → DHCP → NBP (snponly.efi) → iPXE script → kernel/ramdisk.
 
 To switch modes, set `stack_template_path` in `bootstrap_vars.yml` to point to the desired template.
 
@@ -160,7 +160,7 @@ To switch modes, set `stack_template_path` in `bootstrap_vars.yml` to point to t
 - `automation-vars.yml`: Hotloop deployment stages
 - `heat_template.yaml`: OpenStack infrastructure template (redfish-virtual-media)
 - `heat_template_ipxe.yaml`: OpenStack infrastructure template (iPXE boot)
-- `heat_template_pxe.yaml`: OpenStack infrastructure template (PXE boot, BIOS mode)
+- `heat_template_pxe.yaml`: OpenStack infrastructure template (PXE boot via HotPxeChain)
 - `manifests/control-plane/control-plane.yaml`: OpenStack service configuration
 - `test-operator/automation-vars.yml`: Comprehensive test automation
 - `test-operator/tempest-tests.yml`: Tempest test specifications

--- a/scenarios/sno-2-bm/bootstrap_vars.yml
+++ b/scenarios/sno-2-bm/bootstrap_vars.yml
@@ -25,6 +25,8 @@ ovn_k8s_gateway_config_host_routing: true
 enable_iscsi: true
 enable_multipath: true
 
+sushy_emulator_os_rescue_pxe_image_uefi: uefi-netboot
+
 cinder_volume_pvs:
   - /dev/vdc
   - /dev/vdd

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -111,6 +111,7 @@
     attempts: 1
     vars:
       scenario: sno-2-bm
+      sushy_emulator_os_rescue_pxe_image_uefi: uefi-netboot
     files:
       - ^scenarios/sno-2-bm/.*
       - ^roles/redfish_virtual_bmc/.*


### PR DESCRIPTION
Introduce HotPxeChain.efi, a UEFI application that drives the firmware's native PXE boot stack to DHCP and TFTP-download the network boot program (e.g. snponly.efi). Produces clean UEFI PXE client identifiers without iPXE fingerprints, allowing the DHCP server to distinguish boot stages.

Supports DHCPv4 options 67/54/66 with BOOTP field fallback, and DHCPv6 option 59 (boot file URL) with full IPv6 address parsing. Constructs a NIC-rooted device path for LoadImage so SNP-based NBPs can locate their network interface.

Add containerized edk2 build and uefi-netboot disk image target (GPT + ESP with HotPxeChain as BOOTX64.EFI).

NOTE: The HotPxeChain C code was generated by Claude.

Assisted-By: Claude (Opus 4.6)