### PR TITLE
Pass container file arg to docker cmd

### DIFF
--- a/.github/workflows/build-uefi-netboot-image.yml
+++ b/.github/workflows/build-uefi-netboot-image.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "Building HotPxeChain.efi using container build..."
           cd images
-          docker build -t hot-pxe-chain-build:latest hot-pxe-chain/
+          docker build -f hot-pxe-chain/Containerfile -t hot-pxe-chain-build:latest hot-pxe-chain/
           echo "Container build complete"
 
       - name: Extract HotPxeChain.efi from Container


### PR DESCRIPTION
The workflow failed, because docker looks for Dockerfile by default.