### PR TITLE
internal git server, disable recieve-pack

### DIFF
--- a/roles/hotstack_git_server/README.md
+++ b/roles/hotstack_git_server/README.md
@@ -63,7 +63,6 @@ The daemon is started on the default port 9418 with:
 - `--base-path` - Base directory for repositories
 - `--export-all` - Export all repositories
 - `--reuseaddr` - Allow quick restarts
-- `--enable=receive-pack` - Allow git push (for testing)
 - `--verbose` - Log connections
 - `--detach` - Run in background
 

--- a/roles/hotstack_git_server/library/hotstack_git_server_init.py
+++ b/roles/hotstack_git_server/library/hotstack_git_server_init.py
@@ -248,7 +248,6 @@ def manage_git_daemon(module, base_path):
             f"--base-path={base_path}",
             "--export-all",
             "--reuseaddr",
-            "--enable=receive-pack",
             "--verbose",
             "--detach",
         ]


### PR DESCRIPTION
The git server is only accessed by ArgoCD doing read operations, all content change is done in the local repo via git add|commit.