### PR TITLE
Ansible log|output security hardening

### DIFF
--- a/03-install_ocp.yml
+++ b/03-install_ocp.yml
@@ -42,6 +42,7 @@
           {{ stack_outputs.ocp_installer_type | default('agent') }} installer
 
     - name: Slurp the pull-secret file
+      no_log: true
       when: pull_secret_stat.stat.exists
       register: slurp_pull_secret
       ansible.builtin.slurp:

--- a/03-setup_microshift.yml
+++ b/03-setup_microshift.yml
@@ -32,6 +32,7 @@
       ansible.builtin.add_host: "{{ stack_outputs.microshift_ansible_host }}"
 
     - name: Slurp the pull-secret file
+      no_log: true
       register: slurp_pull_secret
       ansible.builtin.slurp:
         src: "{{ pull_secret_file }}"

--- a/roles/controller/tasks/main.yml
+++ b/roles/controller/tasks/main.yml
@@ -24,11 +24,13 @@
   ansible.builtin.add_host: "{{ controller_ansible_host }}"
 
 - name: Read Dataplane SSH private key content
+  no_log: true
   ansible.builtin.slurp:
     src: "{{ dataplane_ssh_private_key_file }}"
   register: _dataplane_ssh_private_key_content
 
 - name: Read Nova migration SSH private key content
+  no_log: true
   ansible.builtin.slurp:
     src: "{{ nova_migration_ssh_private_key_file }}"
   register: _nova_migration_ssh_private_key_content
@@ -100,6 +102,7 @@
         mode: '0644'
 
     - name: Copy Dataplane ssh private key to controller
+      no_log: true
       ansible.builtin.copy:
         content: "{{ _dataplane_ssh_private_key_content.content | b64decode }}"
         dest: >-
@@ -120,6 +123,7 @@
         mode: '0644'
 
     - name: Copy Nova migrate ssh private key to controller
+      no_log: true
       ansible.builtin.copy:
         content: "{{ _nova_migration_ssh_private_key_content.content | b64decode }}"
         dest: >-
@@ -186,6 +190,7 @@
         group: zuul
 
     - name: Write Ironic nodes YAML
+      no_log: true
       when:
         - stack_outputs.ironic_nodes is defined
         - stack_outputs.ironic_nodes | length > 0

--- a/roles/microshift_setup/tasks/main.yml
+++ b/roles/microshift_setup/tasks/main.yml
@@ -23,6 +23,7 @@
   when: ocp_installer_type == 'microshift'
   block:
     - name: Write pull secret to MicroShift node
+      no_log: true
       when: pull_secret | length > 0
       delegate_to: "{{ microshift_host }}"
       become: true

--- a/roles/redfish_vbmc_podman/tasks/main.yml
+++ b/roles/redfish_vbmc_podman/tasks/main.yml
@@ -41,15 +41,15 @@
     group: root
 
 - name: Generate htpasswd
+  no_log: true
   register: _htpasswd
   ansible.builtin.command:
-    cmd: >-
-     htpasswd -nbB
-       {{ redfish_vbmc_podman_username | quote }}
-       {{ redfish_vbmc_podman_password | quote }}
+    cmd: "htpasswd -nBi {{ redfish_vbmc_podman_username | quote }}"
+    stdin: "{{ redfish_vbmc_podman_password }}"
   changed_when: false
 
 - name: Create htpasswd file
+  no_log: true
   become: true
   ansible.builtin.copy:
     content: "{{ _htpasswd.stdout + '\n' }}"

--- a/roles/redfish_virtual_bmc/tasks/main.yml
+++ b/roles/redfish_virtual_bmc/tasks/main.yml
@@ -28,9 +28,11 @@
         state: present
 
     - name: Generate htpasswd
+      no_log: true
       register: _htpasswd
       ansible.builtin.command:
-        cmd: "htpasswd -nbB {{ redfish_username | quote }} {{ redfish_password | quote }}"
+        cmd: "htpasswd -nBi {{ redfish_username | quote }}"
+        stdin: "{{ redfish_password }}"
 
     - name: Copy files to tempdir
       ansible.builtin.copy:
@@ -48,6 +50,7 @@
         - service.yaml
 
     - name: Template the ConfigMap
+      no_log: true
       ansible.builtin.template:
         src: config_map.yaml.j2
         dest: >-


### PR DESCRIPTION
Add `no_log: true` in some tasks, and switch `htpasswd` to use `stdin` for passwords.

These changes ensure potentially sensitiva data is not leaked to logs.