### PR TITLE
sushy-emulator: use secret for htpasswd

### DIFF
--- a/roles/redfish_virtual_bmc/files/deployment.yaml
+++ b/roles/redfish_virtual_bmc/files/deployment.yaml
@@ -31,9 +31,13 @@ spec:
           items:
           - key: config
             path: config.conf
+      - name: sushy-emulator-htpasswd
+        secret:
+          secretName: sushy-emulator-htpasswd
+          defaultMode: 0600  # u=rw
+          items:
           - key: htpasswd
             path: .htpasswd
-            mode: 0600  # u=rw,g=r,o=r
       - name: os-client-config
         secret:
           secretName: os-client-config
@@ -54,7 +58,12 @@ spec:
         - containerPort: 8000
         volumeMounts:
         - name: sushy-emulator-config
-          mountPath: /etc/sushy-emulator/
+          mountPath: /etc/sushy-emulator/config.conf
+          subPath: config.conf
+        - name: sushy-emulator-htpasswd
+          mountPath: /etc/sushy-emulator/.htpasswd
+          subPath: .htpasswd
+          readOnly: true
         - name: os-client-config
           mountPath: /etc/openstack/
         - name: sushy-emulator-state

--- a/roles/redfish_virtual_bmc/tasks/main.yml
+++ b/roles/redfish_virtual_bmc/tasks/main.yml
@@ -50,7 +50,6 @@
         - service.yaml
 
     - name: Template the ConfigMap
-      no_log: true
       ansible.builtin.template:
         src: config_map.yaml.j2
         dest: >-
@@ -58,6 +57,18 @@
             [
               _tempdir.path,
               'config_map.yaml'
+            ] | ansible.builtin.path_join
+          }}
+
+    - name: Template the htpasswd Secret
+      no_log: true
+      ansible.builtin.template:
+        src: htpasswd_secret.yaml.j2
+        dest: >-
+          {{
+            [
+              _tempdir.path,
+              'htpasswd_secret.yaml'
             ] | ansible.builtin.path_join
           }}
 

--- a/roles/redfish_virtual_bmc/templates/config_map.yaml.j2
+++ b/roles/redfish_virtual_bmc/templates/config_map.yaml.j2
@@ -5,8 +5,6 @@ metadata:
   name: sushy-emulator-config
   namespace: sushy-emulator
 data:
-  htpasswd: |
-    {{ _htpasswd.stdout }}
   config: |
     # Listen on all local IP interfaces
     SUSHY_EMULATOR_LISTEN_IP = '::'

--- a/roles/redfish_virtual_bmc/templates/htpasswd_secret.yaml.j2
+++ b/roles/redfish_virtual_bmc/templates/htpasswd_secret.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sushy-emulator-htpasswd
+  namespace: sushy-emulator
+type: Opaque
+stringData:
+  htpasswd: |
+    {{ _htpasswd.stdout }}

--- a/roles/redfish_virtual_bmc/vars/automation-vars.yml
+++ b/roles/redfish_virtual_bmc/vars/automation-vars.yml
@@ -34,6 +34,11 @@ stages:
     wait_conditions:
       - "oc wait -n sushy-emulator configmaps sushy-emulator-config --for jsonpath='{.metadata.name}'=sushy-emulator-config --timeout=30s"
 
+  - name: "Sushy Emulator : htpasswd Secret"
+    manifest: htpasswd_secret.yaml
+    wait_conditions:
+      - "oc wait -n sushy-emulator secret sushy-emulator-htpasswd --for jsonpath='{.metadata.name}'=sushy-emulator-htpasswd --timeout=30s"
+
   - name: "Sushy Emulator : Deployment"
     manifest: deployment.yaml
     wait_conditions:


### PR DESCRIPTION
Use a secret for the htpasswd instead of config map.

Assisted-By: Claude