### PR TITLE
Set globally administered MACs on ironic ports

### DIFF
--- a/scenarios/compact-4-bm/heat_template.yaml
+++ b/scenarios/compact-4-bm/heat_template.yaml
@@ -748,6 +748,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -773,6 +774,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server
@@ -798,6 +800,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:03"
 
   ironic2:
     type: OS::Nova::Server
@@ -823,6 +826,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:04"
 
   ironic3:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-ceos-vlan-netconf/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-ceos-vlan-netconf/heat_template.yaml
@@ -552,6 +552,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -566,6 +567,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-ceos-vlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-ceos-vlan/heat_template.yaml
@@ -552,6 +552,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -566,6 +567,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-ceos-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-ceos-vxlan/heat_template.yaml
@@ -967,6 +967,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -981,6 +982,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-nxos-vlan-netconf/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-nxos-vlan-netconf/heat_template.yaml
@@ -587,6 +587,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -601,6 +602,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-nxos-vlan-restconf/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-nxos-vlan-restconf/heat_template.yaml
@@ -587,6 +587,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -601,6 +602,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-nxsw-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-nxsw-vxlan/heat_template.yaml
@@ -875,6 +875,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -900,6 +901,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-sonic-vlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-sonic-vlan/heat_template.yaml
@@ -569,6 +569,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -583,6 +584,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
+++ b/scenarios/networking-lab/devstack-sonic-vxlan/heat_template.yaml
@@ -1035,6 +1035,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -1060,6 +1061,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm-flat-vlan/heat_template.yaml
+++ b/scenarios/sno-2-bm-flat-vlan/heat_template.yaml
@@ -517,6 +517,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -542,6 +543,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm-ipv6/heat_template.yaml
+++ b/scenarios/sno-2-bm-ipv6/heat_template.yaml
@@ -620,6 +620,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -645,6 +646,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm/heat_template.yaml
+++ b/scenarios/sno-2-bm/heat_template.yaml
@@ -513,6 +513,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -531,6 +532,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm/heat_template_ipxe.yaml
+++ b/scenarios/sno-2-bm/heat_template_ipxe.yaml
@@ -512,6 +512,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -526,6 +527,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm/heat_template_mixed.yaml
+++ b/scenarios/sno-2-bm/heat_template_mixed.yaml
@@ -512,6 +512,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -526,6 +527,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2-bm/heat_template_pxe.yaml
+++ b/scenarios/sno-2-bm/heat_template_pxe.yaml
@@ -512,6 +512,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -526,6 +527,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2nics-force10-10/heat_template.yaml
+++ b/scenarios/sno-2nics-force10-10/heat_template.yaml
@@ -825,6 +825,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -850,6 +851,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-2nics-nxsw/heat_template.yaml
+++ b/scenarios/sno-2nics-nxsw/heat_template.yaml
@@ -781,6 +781,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -806,6 +807,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/sno-nxsw/heat_template.yaml
+++ b/scenarios/sno-nxsw/heat_template.yaml
@@ -770,6 +770,7 @@ resources:
     properties:
       network: {get_resource: ironic0-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -795,6 +796,7 @@ resources:
     properties:
       network: {get_resource: ironic1-br-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server

--- a/scenarios/uni01alpha/heat_template.yaml
+++ b/scenarios/uni01alpha/heat_template.yaml
@@ -1080,6 +1080,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:01"
 
   ironic0:
     type: OS::Nova::Server
@@ -1094,6 +1095,7 @@ resources:
     properties:
       network: {get_resource: ironic-net}
       port_security_enabled: false
+      mac_address: "20:57:f8:bb:00:02"
 
   ironic1:
     type: OS::Nova::Server


### PR DESCRIPTION
Since change[1] ironic-python-agent filters out interfaces with locally administered MAC addresses. Neutron's default base_mac (`fa:16:3e:00:00:00`) is filtered ...

Use prefix `20:57:f8:bb:XX:YY` for ironic nodes in all scenarios.

[1] https://review.opendev.org/c/openstack/ironic-python-agent/+/993999

Assisted-By: Claude (claude-4.6-sonnet-medium)